### PR TITLE
Add Gmail attachment support and improve formatting help docs

### DIFF
--- a/client/src/extrasuite/client/cli.py
+++ b/client/src/extrasuite/client/cli.py
@@ -650,8 +650,12 @@ def cmd_form_create(args: Any) -> None:
 
 def _parse_email_file_args(
     file_path: Path,
-) -> tuple[list[str], str, str, list[str] | None, list[str] | None]:
-    """Read and parse an email markdown file. Returns (to, subject, body, cc, bcc)."""
+    cli_attachments: list[str] | None = None,
+) -> tuple[list[str], str, str, list[str] | None, list[str] | None, list[Path] | None]:
+    """Read and parse an email markdown file.
+
+    Returns (to, subject, body, cc, bcc, attachments).
+    """
     from extrasuite.client.google_api import parse_email_file
 
     if not file_path.exists():
@@ -680,14 +684,28 @@ def _parse_email_file_args(
         if metadata.get("bcc")
         else None
     )
-    return to, subject, body, cc, bcc
+
+    attachments: list[Path] | None = None
+    if cli_attachments:
+        attachments = []
+        for a in cli_attachments:
+            p = Path(a)
+            if not p.exists():
+                print(f"Error: Attachment not found: {p}", file=sys.stderr)
+                sys.exit(1)
+            attachments.append(p)
+
+    return to, subject, body, cc, bcc, attachments
 
 
 def cmd_gmail_compose(args: Any) -> None:
     """Save an email draft from a markdown file with front matter."""
     from extrasuite.client.google_api import create_gmail_draft
 
-    to, subject, body, cc, bcc = _parse_email_file_args(Path(args.file))
+    attach = getattr(args, "attach", None)
+    to, subject, body, cc, bcc, attachments = _parse_email_file_args(
+        Path(args.file), cli_attachments=attach
+    )
 
     access_token = _get_oauth_token(
         args,
@@ -696,7 +714,13 @@ def cmd_gmail_compose(args: Any) -> None:
     )
 
     result = create_gmail_draft(
-        access_token, to=to, subject=subject, body=body, cc=cc, bcc=bcc
+        access_token,
+        to=to,
+        subject=subject,
+        body=body,
+        cc=cc,
+        bcc=bcc,
+        attachments=attachments,
     )
     draft_id = result.get("id", "")
     print(f"Draft saved (id: {draft_id})")
@@ -706,7 +730,10 @@ def cmd_gmail_edit_draft(args: Any) -> None:
     """Update an existing Gmail draft from a markdown file with front matter."""
     from extrasuite.client.google_api import update_gmail_draft
 
-    to, subject, body, cc, bcc = _parse_email_file_args(Path(args.file))
+    attach = getattr(args, "attach", None)
+    to, subject, body, cc, bcc, attachments = _parse_email_file_args(
+        Path(args.file), cli_attachments=attach
+    )
 
     access_token = _get_oauth_token(
         args,
@@ -722,6 +749,7 @@ def cmd_gmail_edit_draft(args: Any) -> None:
         body=body,
         cc=cc,
         bcc=bcc,
+        attachments=attachments,
     )
     print(f"Draft updated (id: {args.draft_id})")
 
@@ -1162,6 +1190,12 @@ def build_parser() -> Any:
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     sp.add_argument("file", help="Markdown file with front matter")
+    sp.add_argument(
+        "--attach",
+        action="append",
+        metavar="FILE",
+        help="Attach a file (can be repeated for multiple attachments)",
+    )
 
     sp = gmail_sub.add_parser(
         "edit-draft",
@@ -1172,6 +1206,12 @@ def build_parser() -> Any:
     )
     sp.add_argument("draft_id", help="Draft ID to update (from compose output)")
     sp.add_argument("file", help="Markdown file with front matter")
+    sp.add_argument(
+        "--attach",
+        action="append",
+        metavar="FILE",
+        help="Attach a file (can be repeated for multiple attachments)",
+    )
 
     sp = gmail_sub.add_parser(
         "help",

--- a/client/src/extrasuite/client/google_api.py
+++ b/client/src/extrasuite/client/google_api.py
@@ -8,14 +8,20 @@ from __future__ import annotations
 
 import base64
 import json
+import mimetypes
 import ssl
 import urllib.error
 import urllib.parse
 import urllib.request
 from datetime import datetime, timedelta
+from email import encoders
+from email.mime.base import MIMEBase
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 import markdown as _markdown
 
@@ -198,17 +204,35 @@ def _build_email_message(
     body: str,
     cc: list[str] | None = None,
     bcc: list[str] | None = None,
+    attachments: list[Path] | None = None,
 ) -> MIMEMultipart:
-    """Build a multipart (plain + HTML) MIME message from a markdown body."""
-    msg = MIMEMultipart("alternative")
+    """Build a multipart MIME message from a markdown body with optional attachments."""
+    if attachments:
+        msg = MIMEMultipart("mixed")
+        body_part = MIMEMultipart("alternative")
+        body_part.attach(MIMEText(body, "plain"))
+        body_part.attach(MIMEText(markdown_to_html(body), "html"))
+        msg.attach(body_part)
+        for filepath in attachments:
+            mime_type, _ = mimetypes.guess_type(str(filepath))
+            if mime_type is None:
+                mime_type = "application/octet-stream"
+            main_type, sub_type = mime_type.split("/", 1)
+            part = MIMEBase(main_type, sub_type)
+            part.set_payload(filepath.read_bytes())
+            encoders.encode_base64(part)
+            part.add_header("Content-Disposition", "attachment", filename=filepath.name)
+            msg.attach(part)
+    else:
+        msg = MIMEMultipart("alternative")
+        msg.attach(MIMEText(body, "plain"))
+        msg.attach(MIMEText(markdown_to_html(body), "html"))
     msg["To"] = ", ".join(to)
     msg["Subject"] = subject
     if cc:
         msg["Cc"] = ", ".join(cc)
     if bcc:
         msg["Bcc"] = ", ".join(bcc)
-    msg.attach(MIMEText(body, "plain"))
-    msg.attach(MIMEText(markdown_to_html(body), "html"))
     return msg
 
 
@@ -219,9 +243,10 @@ def create_gmail_draft(
     body: str,
     cc: list[str] | None = None,
     bcc: list[str] | None = None,
+    attachments: list[Path] | None = None,
 ) -> dict[str, Any]:
     """Create a Gmail draft. Body is markdown and rendered as HTML in the draft."""
-    msg = _build_email_message(to, subject, body, cc, bcc)
+    msg = _build_email_message(to, subject, body, cc, bcc, attachments=attachments)
     raw = base64.urlsafe_b64encode(msg.as_bytes()).decode("ascii")
     return _api_request(
         "https://gmail.googleapis.com/gmail/v1/users/me/drafts",
@@ -239,9 +264,10 @@ def update_gmail_draft(
     body: str,
     cc: list[str] | None = None,
     bcc: list[str] | None = None,
+    attachments: list[Path] | None = None,
 ) -> dict[str, Any]:
     """Update an existing Gmail draft. Body is markdown and rendered as HTML."""
-    msg = _build_email_message(to, subject, body, cc, bcc)
+    msg = _build_email_message(to, subject, body, cc, bcc, attachments=attachments)
     raw = base64.urlsafe_b64encode(msg.as_bytes()).decode("ascii")
     return _api_request(
         f"https://gmail.googleapis.com/gmail/v1/users/me/drafts/{draft_id}",

--- a/client/src/extrasuite/client/help/gmail/README.md
+++ b/client/src/extrasuite/client/help/gmail/README.md
@@ -6,14 +6,25 @@ Gmail - compose and edit email drafts from local markdown files.
   extrasuite contacts search "Alice Example" "Bob Corp"
 
   # 2. Write your email as a markdown file with front matter
-  # 3. Save the draft to Gmail
-  extrasuite gmail compose <file>
+  # 3. Save the draft to Gmail (optionally attach files)
+  extrasuite gmail compose <file> [--attach report.pdf]
 
   # To update an existing draft (draft_id is printed by compose)
-  extrasuite gmail edit-draft <draft_id> <file>
+  extrasuite gmail edit-draft <draft_id> <file> [--attach slides.pdf]
 
 The draft is saved to Gmail. Open Gmail to review and send it.
-Markdown in the body is rendered as HTML in the draft.
+
+## Formatting
+
+Write your email body conversationally, the way you'd write a normal email.
+Basic formatting is supported: **bold**, *italic*, lists, and
+[links](https://example.com). The body is converted to HTML in the draft.
+
+## Attachments
+
+Add --attach to include files with the draft. Repeat for multiple files:
+
+  extrasuite gmail compose email.md --attach report.pdf --attach data.csv
 
 ## Commands
 

--- a/client/src/extrasuite/client/help/gmail/compose.md
+++ b/client/src/extrasuite/client/help/gmail/compose.md
@@ -2,11 +2,15 @@ Save an email as a Gmail draft from a markdown file with front matter.
 
 ## Usage
 
-  extrasuite gmail compose <file>
+  extrasuite gmail compose <file> [--attach FILE ...]
 
 ## Arguments
 
   file    Path to the markdown file with YAML front matter
+
+## Options
+
+  --attach FILE    Attach a file to the draft (repeat for multiple files)
 
 ## File Format
 
@@ -18,21 +22,47 @@ cc: charlie@example.com
 bcc: dave@example.com
 ---
 
-# Heading
+Hi team,
 
-Email body in **markdown**. Supports:
+Here are the notes from today's meeting. A few highlights:
 
-- Bold, italic, lists
-- Tables
-- Headings
+- **Launch date** moved to March 15
+- We're dropping the legacy integration (see the *updated* proposal)
+- Next sync is Friday at 2pm
 
-Multiple paragraphs are preserved.
+Let me know if I missed anything.
+
+Best,
+Alice
 ```
 
 Required front matter fields: subject, to
 Optional front matter fields: cc, bcc
 
 Multiple recipients: comma-separated in a single field value.
+
+## Formatting
+
+Write your email body the way you'd write a normal email - keep it
+conversational with minimal structure. Basic formatting is supported:
+
+- **bold** and *italic* for emphasis
+- Bulleted and numbered lists
+- [Links](https://example.com)
+- Simple tables
+- Line breaks are preserved
+
+You generally don't need headings or heavy formatting in emails.
+
+## Attachments
+
+Use --attach to include files with the draft:
+
+  extrasuite gmail compose email.md --attach report.pdf
+  extrasuite gmail compose email.md --attach report.pdf --attach data.csv
+
+Any file type is supported. The MIME type is detected automatically from
+the file extension. Repeat --attach for multiple files.
 
 ## Output
 
@@ -41,7 +71,7 @@ Prints the draft ID on success. Save it to update the draft later with edit-draf
 ## Notes
 
 - The draft is saved to the authenticated user's Gmail account
-- Markdown in the body is converted to HTML - the draft will be formatted
+- The body is converted to HTML - the draft will appear formatted in Gmail
 - A plain-text fallback is also included for email clients that don't render HTML
 - Open Gmail to review, edit, and send the draft
 - Use `extrasuite gmail edit-draft <draft_id> <file>` to update the draft

--- a/client/src/extrasuite/client/help/gmail/edit-draft.md
+++ b/client/src/extrasuite/client/help/gmail/edit-draft.md
@@ -2,12 +2,16 @@ Update an existing Gmail draft from a markdown file with front matter.
 
 ## Usage
 
-  extrasuite gmail edit-draft <draft_id> <file>
+  extrasuite gmail edit-draft <draft_id> <file> [--attach FILE ...]
 
 ## Arguments
 
   draft_id    Draft ID to update (printed by `extrasuite gmail compose`)
   file        Markdown file with YAML front matter
+
+## Options
+
+  --attach FILE    Attach a file to the draft (repeat for multiple files)
 
 ## File Format
 
@@ -19,12 +23,20 @@ subject: Updated subject
 to: alice@example.com
 ---
 
-Updated body in **markdown**.
+Updated body with **bold** and *italic* for emphasis.
 ```
+
+## Attachments
+
+Use --attach to include files with the updated draft:
+
+  extrasuite gmail edit-draft abc123 email.md --attach slides.pdf
+
+Repeat --attach for multiple files. Any file type is supported.
 
 ## Notes
 
-- Replaces the entire draft content (subject, recipients, body)
+- Replaces the entire draft content (subject, recipients, body, attachments)
 - The draft ID is printed by `extrasuite gmail compose` on success
-- Markdown is converted to HTML; a plain-text fallback is also included
+- The body is converted to HTML; a plain-text fallback is also included
 - Open Gmail to review, edit, and send the draft


### PR DESCRIPTION
Add --attach flag to gmail compose and edit-draft commands, allowing
file attachments via repeated --attach FILE arguments. MIME types are
auto-detected from file extensions. Also rewrite help docs to guide
toward conversational email tone with basic formatting (bold, italic,
lists, links) rather than suggesting full markdown syntax.

https://claude.ai/code/session_01SHhoZkXFAk7o4xvxQ8zrF9