### PR TITLE
docs: refresh extrasheet and sheet help

### DIFF
--- a/client/src/extrasuite/client/help/sheet/README.md
+++ b/client/src/extrasuite/client/help/sheet/README.md
@@ -2,55 +2,88 @@ Google Sheets - edit spreadsheets via local TSV and JSON files.
 
 ## Workflow
 
-  extrasuite sheet pull <url> [output_dir]   Download spreadsheet
+  extrasuite sheet pull <url> [output_dir]
   # Edit files in <output_dir>/<spreadsheet_id>/
-  extrasuite sheet push <folder>             Apply changes to Google Sheets
-  extrasuite sheet create <title>            Create a new spreadsheet
+  extrasuite sheet diff <folder>
+  extrasuite sheet push <folder>
 
 After push, always re-pull before making more changes.
+
+## Start Here
+
+  spreadsheet.json   Overview of the spreadsheet, sheet list, previews, and any truncation hints
+
+If a pull was row-limited, `spreadsheet.json` may contain:
+
+  sheets[].truncation     Per-sheet details about totalRows vs fetchedRows
+  _truncationWarning      Top-level warning that one or more sheets are partial
 
 ## Directory Structure
 
   <spreadsheet_id>/
-    spreadsheet.json        START HERE - title, sheet list, data previews
+    spreadsheet.json        Required
+    theme.json              Optional, informational only
+    named_ranges.json       Optional, editable
+    developer_metadata.json Optional, informational only
+    data_sources.json       Optional, informational only
     <sheet_name>/
-      data.tsv              Cell values (raw, unformatted, 100 rows max by default)
-      formula.json          Formulas only (omitted if no formulas)
-      format.json           Colors, fonts, number formats (omitted if all default)
-      dimension.json        Row heights and column widths
+      data.tsv              Cell values
+      formula.json          Formulas
+      format.json           Cell formatting, merges, notes, rich text
+      dimension.json        Row/column size + hidden state
+      charts.json           Charts
+      pivot-tables.json     Pivot tables
+      tables.json           Structured tables
+      filters.json          Basic filter + filter views
+      banded-ranges.json    Alternating colors
+      data-validation.json  Dropdowns, checkboxes, validation rules
+      slicers.json          Interactive slicers
+      data-source-tables.json Data source tables
+      protection.json       Optional, informational only
+      comments.json         Optional, replies/resolve only
     .pristine/              Internal state - do not edit
     .raw/                   Raw API responses - do not edit
 
-## Files and When to Edit
+## Editable Surface
 
-  spreadsheet.json   Title, sheet names, frozen rows/cols, tab colors, add/delete sheets
+  spreadsheet.json   Spreadsheet title; sheet title, hidden, right-to-left, tab color, frozen rows/cols
   data.tsv           Cell values, insert/delete rows and columns
-  formula.json       Add, modify, or delete formulas (range compression supported)
-  format.json        Backgrounds, text format, number format, conditional formats, merges
-  dimension.json     Column widths and row heights
+  formula.json       Add, modify, or delete formulas
+  format.json        Formats, conditional formats, merges, notes, rich text runs
+  dimension.json     Row/column sizes and hidden state
+  charts.json        Add, update, or delete charts
+  pivot-tables.json  Add, update, or delete pivot tables
+  tables.json        Add, update, or delete structured tables
+  filters.json       Basic filter and filter views
+  banded-ranges.json Alternating colors
+  data-validation.json Input validation rules
+  slicers.json       Add, update, or delete slicers
+  named_ranges.json  Spreadsheet named ranges
+  comments.json      Add replies or resolve existing comments
 
-Optional files (only created when content exists):
-  charts.json, data-validation.json, filters.json, pivot-tables.json,
-  banded-ranges.json, tables.json, slicers.json, named_ranges.json,
-  comments.json
+Currently informational only on push:
+
+  theme.json, developer_metadata.json, data_sources.json, protection.json
+  dimension.json rowGroups/columnGroups/developerMetadata
+  spreadsheet.json properties.locale / autoRecalc / timeZone
 
 ## Key Rules
 
-  data.tsv has raw values: write 8000 not $8,000; write 0.72 not 72%
-  Formula cells: leave blank in data.tsv, define in formula.json
-  Re-pull after every push (pristine state is not auto-updated)
+  data.tsv stores raw values: write 8000 not $8,000; write 0.72 not 72%
+  Formula cells should stay blank in data.tsv and be defined in formula.json
+  Cell notes live in format.json; Drive comments live in comments.json
+  Re-pull after every push because pristine state is not auto-updated
 
 ## Commands
 
   extrasuite sheet pull --help        Pull flags and folder layout details
-  extrasuite sheet push --help        Push flags
-  extrasuite sheet diff --help        Offline debugging tool (no auth needed)
+  extrasuite sheet diff --help        Preview requests and comment ops
+  extrasuite sheet push --help        Apply local changes
   extrasuite sheet create --help      Create a new spreadsheet
-  extrasuite sheet batchUpdate --help Execute raw API requests (sort, move, etc.)
+  extrasuite sheet batchUpdate --help Execute raw API requests directly
 
-## Reference Docs (detailed)
+## Reference Docs
 
-  extrasuite sheet help                    List available reference topics
-  extrasuite sheet help format-reference   Colors, borders, conditional formats, merges, rich text
-  extrasuite sheet help features-reference Charts, data validation, pivot tables, named ranges
-  extrasuite sheet help comments-reference Comments: add replies, resolve
+  extrasuite sheet help format-reference    format.json and dimension.json details
+  extrasuite sheet help features-reference  charts, filters, pivot tables, tables, named ranges
+  extrasuite sheet help comments-reference  comments.json format and limits

--- a/client/src/extrasuite/client/help/sheet/comments-reference.md
+++ b/client/src/extrasuite/client/help/sheet/comments-reference.md
@@ -1,6 +1,9 @@
 # comments.json Reference
 
-Cell comments for a sheet. Only created by pull if the sheet has at least one comment.
+Drive comments for a single sheet. This file lives inside a sheet folder and is
+only created when that sheet has at least one comment.
+
+This is separate from `format.json` cell notes.
 
 ## Format
 

--- a/client/src/extrasuite/client/help/sheet/features-reference.md
+++ b/client/src/extrasuite/client/help/sheet/features-reference.md
@@ -1,143 +1,211 @@
 # Sheet Features Reference
 
-Advanced spreadsheet features: charts, data validation, filters, pivot tables, named ranges.
+Advanced sheet and spreadsheet features are stored in separate JSON files so an
+agent can load only what it needs.
 
-All on-disk formats use A1 notation consistently. The diff engine converts to
-0-based indices when generating API requests.
+Most range-like fields use A1 notation. Sheet folder paths are per-sheet unless
+noted otherwise.
 
----
-
-## Charts (charts.json)
-
-```json
-{
-  "charts": [{
-    "chartId": 123456,
-    "position": {
-      "overlayPosition": {
-        "anchorCell": "F1",
-        "widthPixels": 600,
-        "heightPixels": 400
-      }
-    },
-    "spec": {
-      "title": "Sales by Region",
-      "basicChart": {
-        "chartType": "COLUMN",
-        "legendPosition": "BOTTOM_LEGEND",
-        "domains": [{"domain": {"sourceRange": {"sources": [{"range": "A2:A10"}]}}}],
-        "series": [{"series": {"sourceRange": {"sources": [{"range": "B2:B10"}]}},
-                    "targetAxis": "LEFT_AXIS"}]
-      }
-    }
-  }]
-}
-```
-
-Chart types: BAR, COLUMN, LINE, PIE, SCATTER, AREA, COMBO
-
-Pie charts use a different structure (singular domain/series, not arrays):
-  "pieChart": {"domain": {...}, "series": {...}}
-
-Basic charts (bar, column, line, scatter, area) use plural arrays:
-  "basicChart": {"domains": [...], "series": [...]}
-
----
-
-## Data Validation (data-validation.json)
+## charts.json
 
 ```json
 {
-  "dataValidation": [{
-    "range": "H2:H100",
-    "rule": {
-      "condition": {
-        "type": "ONE_OF_LIST",
-        "values": [
-          {"userEnteredValue": "Option A"},
-          {"userEnteredValue": "Option B"}
-        ]
+  "charts": [
+    {
+      "chartId": 123456,
+      "position": {
+        "overlayPosition": {
+          "anchorCell": "F1",
+          "widthPixels": 600,
+          "heightPixels": 400
+        }
       },
-      "showCustomUi": true,
-      "strict": true
+      "spec": {
+        "title": "Sales by Region",
+        "basicChart": {
+          "chartType": "COLUMN",
+          "domains": [{"domain": {"sourceRange": {"sources": [{"range": "A2:A10"}]}}}],
+          "series": [{"series": {"sourceRange": {"sources": [{"range": "B2:B10"}]}}}]
+        }
+      }
     }
-  }]
+  ]
 }
 ```
 
-Condition types:
-  ONE_OF_LIST     Dropdown with fixed values
-  ONE_OF_RANGE    Dropdown from cell range: {"userEnteredValue": "='Lookup'!A:A"}
-  BOOLEAN         Checkbox
-  NUMBER_BETWEEN  Number range constraint
-  CUSTOM_FORMULA  Custom validation formula
+## pivot-tables.json
 
-Note: TEXT_IS_VALID_EMAIL and TEXT_IS_VALID_URL are not supported - use CUSTOM_FORMULA.
+```json
+{
+  "pivotTables": [
+    {
+      "anchorCell": "G1",
+      "source": "A1:E100",
+      "rows": [{"sourceColumnOffset": 0, "showTotals": true}],
+      "columns": [{"sourceColumnOffset": 1}],
+      "values": [{"sourceColumnOffset": 2, "summarizeFunction": "SUM"}]
+    }
+  ]
+}
+```
 
----
+Pivot tables are matched by `anchorCell`.
 
-## Filters (filters.json)
+## tables.json
 
-Basic filter (applies to entire sheet):
+```json
+{
+  "tables": [
+    {
+      "tableId": "1778223018",
+      "name": "Table1",
+      "range": "A1:J47",
+      "columnProperties": [
+        {"column": "A", "columnName": "Category"},
+        {"column": "B", "columnName": "Resource Type"}
+      ]
+    }
+  ]
+}
+```
+
+## filters.json
+
 ```json
 {
   "basicFilter": {
     "range": "A1:E100",
-    "filterSpecs": [{
-      "column": "C",
-      "filterCriteria": {
-        "condition": {"type": "TEXT_CONTAINS", "values": [{"userEnteredValue": "Active"}]}
+    "filterSpecs": [
+      {
+        "column": "C",
+        "filterCriteria": {
+          "condition": {"type": "TEXT_CONTAINS", "values": [{"userEnteredValue": "Active"}]}
+        }
       }
-    }]
-  }
+    ]
+  },
+  "filterViews": [
+    {
+      "filterViewId": 789,
+      "title": "Active Only",
+      "range": "A1:E100",
+      "filterSpecs": []
+    }
+  ]
 }
 ```
 
-Named filter views (users can switch between):
-```json
-{
-  "filterViews": [{
-    "filterViewId": 789,
-    "title": "Active Only",
-    "range": "A1:E100",
-    "filterSpecs": [...]
-  }]
-}
-```
-
----
-
-## Pivot Tables (pivot-tables.json)
+## banded-ranges.json
 
 ```json
 {
-  "pivotTables": [{
-    "anchorCell": "G1",
-    "source": "A1:E100",
-    "rows": [{"sourceColumnOffset": 0, "showTotals": true}],
-    "columns": [{"sourceColumnOffset": 1}],
-    "values": [{"sourceColumnOffset": 2, "summarizeFunction": "SUM"}]
-  }]
+  "bandedRanges": [
+    {
+      "bandedRangeId": 123,
+      "range": "A1:J100",
+      "rowProperties": {
+        "headerColor": "#336699",
+        "firstBandColor": "#FFFFFF",
+        "secondBandColor": "#F2F2F2"
+      }
+    }
+  ]
 }
 ```
 
-sourceColumnOffset is 0-based into the source range columns.
-Summarize functions: SUM, COUNT, AVERAGE, MIN, MAX, COUNTA, COUNTUNIQUE
-
----
-
-## Named Ranges (named_ranges.json)
-
-Spreadsheet-level (not per-sheet):
+## data-validation.json
 
 ```json
 {
-  "namedRanges": [{
-    "namedRangeId": "abc123",
-    "name": "SalesData",
-    "range": "Sheet1!A1:E100"
-  }]
+  "dataValidation": [
+    {
+      "range": "H2... (49 cells)",
+      "cells": ["H2", "H3", "H4"],
+      "rule": {
+        "condition": {
+          "type": "ONE_OF_LIST",
+          "values": [
+            {"userEnteredValue": "Option A"},
+            {"userEnteredValue": "Option B"}
+          ]
+        },
+        "showCustomUi": true,
+        "strict": true
+      }
+    }
+  ]
 }
 ```
 
-Use in formulas: =SUM(SalesData), =AVERAGE(SalesData)
+The `range` field is a summary string; `cells` is the canonical list.
+
+## slicers.json
+
+```json
+{
+  "slicers": [
+    {
+      "slicerId": 456,
+      "position": {
+        "overlayPosition": {
+          "anchorCell": "M1",
+          "widthPixels": 200,
+          "heightPixels": 300
+        }
+      },
+      "spec": {
+        "dataRange": "A1:E100",
+        "title": "Region Filter",
+        "column": "C"
+      }
+    }
+  ]
+}
+```
+
+## data-source-tables.json
+
+```json
+{
+  "dataSourceTables": [
+    {
+      "anchorCell": "M1",
+      "dataSourceId": "datasource_abc",
+      "columns": []
+    }
+  ]
+}
+```
+
+Current support is limited. Modify/refresh-style changes work better than
+creating or deleting these tables.
+
+## named_ranges.json
+
+Spreadsheet-level, not per-sheet:
+
+```json
+{
+  "namedRanges": [
+    {
+      "namedRangeId": "abc123",
+      "name": "SalesData",
+      "range": "Sheet1!A1:E100"
+    }
+  ]
+}
+```
+
+## Informational Pull-Only Files
+
+These may appear in a pull but are not currently applied by push:
+
+  theme.json
+  developer_metadata.json
+  data_sources.json
+  protection.json
+
+## Related
+
+  extrasuite sheet help format-reference     cell formatting, notes, rich text
+  extrasuite sheet help comments-reference   Drive comments

--- a/client/src/extrasuite/client/help/sheet/format-reference.md
+++ b/client/src/extrasuite/client/help/sheet/format-reference.md
@@ -1,6 +1,13 @@
 # format.json Reference
 
-Formatting rules for cells: colors, fonts, number formats, conditional formats, merges, notes, rich text.
+`format.json` stores cell formatting, conditional formats, merges, cell notes,
+and rich text runs.
+
+This file does not contain:
+
+  banded-ranges.json    Alternating colors
+  dimension.json        Row/column sizing and hidden state
+  comments.json         Drive comments
 
 ## Structure
 
@@ -14,9 +21,7 @@ Formatting rules for cells: colors, fonts, number formats, conditional formats, 
 }
 ```
 
-All colors use hex strings: "#RRGGBB"
-
----
+Concrete editable color values use hex strings such as `"#RRGGBB"`.
 
 ## Format Rules
 
@@ -43,54 +48,46 @@ Apply formatting to cell ranges:
 }
 ```
 
-Common format properties:
+Common properties:
 
-  backgroundColor             Hex color ("#FF0000")
-  textFormat.bold             true / false
-  textFormat.italic           true / false
-  textFormat.fontSize         Integer (points)
-  textFormat.foregroundColor  Hex color
-  textFormat.strikethrough    true / false
-  textFormat.underline        true / false
-  horizontalAlignment         LEFT, CENTER, RIGHT
-  verticalAlignment           TOP, MIDDLE, BOTTOM
-  numberFormat.type           NUMBER, CURRENCY, DATE, PERCENT, TEXT
-  numberFormat.pattern        Format string (e.g. "$#,##0.00", "MMM d, yyyy")
-  wrapStrategy               OVERFLOW_CELL (default), WRAP, CLIP
-  padding                     {"top": 5, "bottom": 5, "left": 10, "right": 10} (pixels)
-  textDirection               LEFT_TO_RIGHT, RIGHT_TO_LEFT
-  textRotation                {"angle": 45} (-90 to 90) or {"vertical": true}
-
-Note: formatRules uses "range" (singular string). conditionalFormats uses "ranges"
-(plural array) because one rule can apply to multiple disjoint ranges.
-
----
+  backgroundColor               Hex color
+  textFormat.bold               true / false
+  textFormat.italic             true / false
+  textFormat.fontSize           Integer points
+  textFormat.foregroundColor    Hex color
+  textFormat.strikethrough      true / false
+  textFormat.underline          true / false
+  textFormat.link               {"uri": "https://..."}
+  horizontalAlignment           LEFT, CENTER, RIGHT
+  verticalAlignment             TOP, MIDDLE, BOTTOM
+  numberFormat.type             NUMBER, CURRENCY, DATE, PERCENT, TEXT
+  numberFormat.pattern          Format string
+  wrapStrategy                  OVERFLOW_CELL, WRAP, CLIP
+  padding                       {"top": 5, "bottom": 5, "left": 10, "right": 10}
+  textDirection                 LEFT_TO_RIGHT, RIGHT_TO_LEFT
+  textRotation                  {"angle": 45} or {"vertical": true}
 
 ## Borders
 
 ```json
 {
-  "formatRules": [{
-    "range": "A1:D10",
-    "format": {
-      "borders": {
-        "top":    {"style": "SOLID", "color": "#000000"},
-        "bottom": {"style": "SOLID", "color": "#000000"},
-        "left":   {"style": "SOLID"},
-        "right":  {"style": "SOLID"}
+  "formatRules": [
+    {
+      "range": "A1:D10",
+      "format": {
+        "borders": {
+          "top": {"style": "SOLID", "color": "#000000"},
+          "bottom": {"style": "SOLID", "color": "#000000"},
+          "left": {"style": "SOLID"},
+          "right": {"style": "SOLID"}
+        }
       }
     }
-  }]
+  ]
 }
 ```
 
-Border sides: top, bottom, left, right
-Each side: style (required), color (optional hex), width (optional integer pixels)
 Styles: SOLID, DASHED, DOTTED, DOUBLE, SOLID_MEDIUM, SOLID_THICK
-
-To clear borders: remove the format rule that contained them.
-
----
 
 ## Conditional Formatting
 
@@ -98,44 +95,44 @@ To clear borders: remove the format rule that contained them.
 
 ```json
 {
-  "conditionalFormats": [{
-    "ruleIndex": 0,
-    "ranges": ["B2:B100"],
-    "booleanRule": {
-      "condition": {
-        "type": "NUMBER_GREATER",
-        "values": [{"userEnteredValue": "1000"}]
-      },
-      "format": {"backgroundColor": "#CCFFCC"}
+  "conditionalFormats": [
+    {
+      "ruleIndex": 0,
+      "ranges": ["B2:B100"],
+      "booleanRule": {
+        "condition": {
+          "type": "NUMBER_GREATER",
+          "values": [{"userEnteredValue": "1000"}]
+        },
+        "format": {"backgroundColor": "#CCFFCC"}
+      }
     }
-  }]
+  ]
 }
 ```
-
-Condition types: NUMBER_GREATER, NUMBER_LESS, NUMBER_BETWEEN, NUMBER_EQUAL,
-TEXT_CONTAINS, TEXT_STARTS_WITH, TEXT_ENDS_WITH, TEXT_EQ,
-DATE_BEFORE, DATE_AFTER, BLANK, NOT_BLANK, CUSTOM_FORMULA
-
-Custom formula: {"type": "CUSTOM_FORMULA", "values": [{"userEnteredValue": "=A2>B2"}]}
 
 ### Gradient Rules
 
 ```json
 {
-  "ruleIndex": 1,
-  "ranges": ["C2:C100"],
-  "gradientRule": {
-    "minpoint": {"color": "#FFCCCC", "type": "MIN"},
-    "maxpoint": {"color": "#CCFFCC", "type": "MAX"}
-  }
+  "conditionalFormats": [
+    {
+      "ranges": ["C2:C100"],
+      "gradientRule": {
+        "minpoint": {"color": "#FFCCCC", "type": "MIN"},
+        "maxpoint": {"color": "#CCFFCC", "type": "MAX"}
+      }
+    }
+  ]
 }
 ```
 
-Point types: MIN, MAX, NUMBER, PERCENT, PERCENTILE
+Notes:
 
----
+  Existing rules should keep their ruleIndex
+  New rules may omit ruleIndex; diff will assign one after the last existing rule
 
-## Cell Merges
+## Merges
 
 ```json
 {
@@ -143,26 +140,20 @@ Point types: MIN, MAX, NUMBER, PERCENT, PERCENTILE
 }
 ```
 
-Uses A1 notation. The diff engine converts to 0-based indices automatically.
-
----
-
 ## Cell Notes
 
 ```json
 {
   "notes": {
-    "A1": "This is a comment on cell A1",
+    "A1": "This is a note on cell A1",
     "B5": "Another note"
   }
 }
 ```
 
----
+These are cell notes, not Drive comments. Drive comments live in `comments.json`.
 
-## Rich Text (textFormatRuns)
-
-Apply different formatting to parts of a cell's text:
+## Rich Text
 
 ```json
 {
@@ -176,43 +167,10 @@ Apply different formatting to parts of a cell's text:
 }
 ```
 
-startIndex is 0-based character position. Each run applies from startIndex to
-the next run's startIndex (or end of cell).
+`startIndex` is a 0-based character offset within the cell text.
 
----
+## Related Files
 
-## Banded Ranges (Alternating Colors)
-
-```json
-{
-  "bandedRanges": [{
-    "bandedRangeId": 123,
-    "range": "A1:J100",
-    "rowProperties": {
-      "headerColor": "#336699",
-      "firstBandColor": "#FFFFFF",
-      "secondBandColor": "#F2F2F2"
-    }
-  }]
-}
-```
-
----
-
-## Dimension Sizing (dimension.json)
-
-```json
-{
-  "rowMetadata": [
-    {"row": 1, "pixelSize": 30},
-    {"row": 11, "pixelSize": 50, "hidden": true}
-  ],
-  "columnMetadata": [
-    {"column": "A", "pixelSize": 150},
-    {"column": "F", "pixelSize": 200}
-  ]
-}
-```
-
-rowMetadata: 1-based row numbers. columnMetadata: column letters.
-hidden: true hides the row/column. Remove entry to reset to default size.
+  extrasuite sheet help features-reference   charts, filters, pivot tables, tables, banded ranges
+  dimension.json                             row/column size and hidden state
+  comments.json                              Drive comments

--- a/client/src/extrasuite/client/help/sheet/pull.md
+++ b/client/src/extrasuite/client/help/sheet/pull.md
@@ -12,34 +12,45 @@ Download a Google Sheet to a local folder.
 ## Flags
 
   --max-rows N  Max rows per sheet to download (default: 100)
-  --no-limit    Download all rows (use for complete data access)
+  --no-limit    Download all rows
   --no-raw      Skip saving raw API responses (.raw/ folder)
 
 ## Output
 
 Creates <output_dir>/<spreadsheet_id>/ with:
 
-  spreadsheet.json        Spreadsheet title, sheet list, data previews (first 5 + last 3 rows)
+  spreadsheet.json          Spreadsheet metadata, sheet list, previews, truncation hints
+  theme.json                Default format and theme metadata (if present)
+  named_ranges.json         Spreadsheet named ranges (if present)
+  developer_metadata.json   Spreadsheet developer metadata (if present)
+  data_sources.json         Spreadsheet data source metadata (if present)
   <sheet_name>/
-    data.tsv              Raw cell values (tab-separated, no header row offset)
-    formula.json          Formulas (only present if sheet has formulas)
-    format.json           Formatting rules (only present if non-default formatting exists)
-    dimension.json        Row heights and column widths (only present if non-default)
-    charts.json           Chart definitions (if charts exist)
-    data-validation.json  Dropdowns, checkboxes (if present)
-    filters.json          Filter views (if present)
-    pivot-tables.json     Pivot tables (if present)
-    comments.json         Cell comments (only present if comments exist)
-  .pristine/              Snapshot for diff/push comparison - do not edit
-  .raw/                   Raw API responses for debugging - do not edit
+    data.tsv                Raw cell values
+    formula.json            Formulas (or {} for empty GRID sheets)
+    format.json             Formatting, merges, notes, rich text (if present)
+    dimension.json          Row/column size + hidden state (if present)
+    charts.json             Charts (if present)
+    pivot-tables.json       Pivot tables (if present)
+    tables.json             Structured tables (if present)
+    filters.json            Basic filter + filter views (if present)
+    banded-ranges.json      Alternating colors (if present)
+    data-validation.json    Validation rules (if present)
+    slicers.json            Slicers (if present)
+    data-source-tables.json Data source tables (if present)
+    protection.json         Protected ranges (if present)
+    comments.json           Drive comments for that sheet (if present)
+  .pristine/                Snapshot for diff/push comparison - do not edit
+  .raw/                     Raw API responses for debugging - do not edit
 
 ## Notes
 
-- Start by reading spreadsheet.json for the overview
-- The preview in spreadsheet.json (first 5 + last 3 rows) is often enough
-- Read data.tsv only when you need to see or modify the actual cell data
-- When a sheet has more than --max-rows rows, spreadsheet.json shows a truncation warning
-- Use --no-limit to download all rows for large sheets that need complete data
+- Start with `spreadsheet.json`
+- `preview.firstRows` / `preview.lastRows` are often enough for orientation
+- If any sheet was truncated, `spreadsheet.json` includes `_truncationWarning`
+  and `sheets[].truncation`
+- `comments.json` is separate from cell notes in `format.json`
+- Some pulled files are informational only today: `theme.json`,
+  `developer_metadata.json`, `data_sources.json`, and `protection.json`
 
 ## Example
 

--- a/client/src/extrasuite/client/help/sheet/push.md
+++ b/client/src/extrasuite/client/help/sheet/push.md
@@ -6,7 +6,7 @@ Apply local changes to Google Sheets.
 
 ## Arguments
 
-  folder    Path to the spreadsheet folder (created by pull)
+  folder    Path to the spreadsheet folder created by pull
 
 ## Flags
 
@@ -14,35 +14,64 @@ Apply local changes to Google Sheets.
 
 ## How It Works
 
-Compares current files against .pristine/ snapshot, generates batchUpdate
-requests, and applies them to Google Sheets in a single API call.
+Push compares the current files against `.pristine/spreadsheet.zip`, validates
+structural changes, generates Google Sheets `batchUpdate` requests, applies
+those requests, then applies supported `comments.json` operations through the
+Drive API.
 
-## After Push
+## Editable Files
 
-Always re-pull before making more changes. The .pristine/ snapshot is not
-auto-updated, so subsequent pushes would generate incorrect diffs.
+Push currently honors edits in:
 
-  extrasuite sheet push ./abc123
-  extrasuite sheet pull https://docs.google.com/spreadsheets/d/abc123 .
+  spreadsheet.json        Spreadsheet title; sheet title/hidden/RTL/tab color/frozen rows/cols
+  data.tsv                Cell values and row/column insert/delete
+  formula.json            Formulas
+  format.json             Cell formats, conditional formats, merges, notes, rich text
+  dimension.json          Row/column size and hidden state
+  charts.json             Charts
+  pivot-tables.json       Pivot tables
+  tables.json             Structured tables
+  filters.json            Basic filter + filter views
+  banded-ranges.json      Alternating colors
+  data-validation.json    Validation rules
+  slicers.json            Slicers
+  data-source-tables.json Limited support only
+  named_ranges.json       Named ranges
+  comments.json           New replies and comment resolution
 
-## Validation
+Push currently ignores edits in:
 
-Push validates changes before sending them. Blocked operations will print
-an error and exit. Warnings can be bypassed with --force if you're certain
-the change is correct.
+  theme.json
+  developer_metadata.json
+  data_sources.json
+  protection.json
+  dimension.json rowGroups / columnGroups / developerMetadata
+  spreadsheet.json properties.locale / autoRecalc / timeZone
 
 ## Comments
 
-Push also applies changes to `comments.json` via the Drive API:
-- Add a reply: add an entry to `replies` without an `id` field
-- Resolve a comment: set `"resolved": true`
-- Creating new top-level comments is not supported
+Push supports these `comments.json` operations:
 
-See `extrasuite sheet help comments-reference` for format details and examples.
+  Add a reply     Add a reply object without an `id`
+  Resolve         Set `"resolved": true`
 
-## Notes
+Not supported:
 
-- All edits to data.tsv, formula.json, format.json, etc. are applied in one push
-- Adding/deleting sheets and changing cell values all happen in one operation
-- Comment operations are applied after sheet data changes
-- If push fails partway through, re-pull to see the current state
+  Create new top-level comments
+
+See `extrasuite sheet help comments-reference` for the file format.
+
+## After Push
+
+Always re-pull before making more changes. `.pristine` is not auto-updated, so
+reusing the same folder after a push will generate stale diffs.
+
+## Validation
+
+Push validates structural edits before sending requests:
+
+  BLOCK    Push fails
+  WARN     Push requires --force
+
+Typical causes include row/column insertions or deletions that conflict with
+formula edits.

--- a/extrasheet/CLAUDE.md
+++ b/extrasheet/CLAUDE.md
@@ -1,276 +1,102 @@
 ## Overview
 
-Python library that transforms Google Sheets into a file-based representation optimized for LLM agents. Implements the pull/diff/push workflow.
+Python library that implements the Google Sheets pull/diff/push workflow used by
+`extrasuite sheet`.
 
-Instead of working with complex API responses, agents interact with simple files:
-- **data.tsv** - Cell values in tab-separated format (formulas show computed values)
-- **formula.json** - Sparse dictionary mapping cell coordinates to formulas (with compression)
-- **format.json** - Cell formatting definitions (with compression)
-- **feature.json** - Advanced features (charts, pivot tables, filters, etc.)
+The current on-disk model is split by concern:
+- `spreadsheet.json` for spreadsheet metadata, sheet list, previews, and
+  truncation hints
+- `data.tsv` for cell values
+- `formula.json` for formulas
+- `format.json` for cell formatting, merges, notes, and text format runs
+- Separate feature files such as `charts.json`, `filters.json`,
+  `pivot-tables.json`, and `data-validation.json`
+- Optional per-sheet `comments.json` files fetched via Drive comments
+
+Do not describe the current format as `feature.json`-based except when talking
+about backward compatibility in the diff engine.
 
 ## Key Files
 
 | File | Purpose |
 |------|---------|
-| `src/extrasheet/transport.py` | `Transport` ABC, `GoogleSheetsTransport`, `LocalFileTransport` |
-| `src/extrasheet/client.py` | `SheetsClient` - main interface with `pull()`, `diff()`, `push()` methods |
-| `src/extrasheet/transformer.py` | Transforms API response to on-disk format |
-| `src/extrasheet/writer.py` | Writes transformed data to files |
-| `src/extrasheet/formula_compression.py` | Compresses formulas with relative references |
-| `src/extrasheet/format_compression.py` | Compresses cell formatting |
-| `src/extrasheet/api_types.py` | TypedDict definitions for Google Sheets API |
-| `src/extrasheet/utils.py` | A1 notation parsing utilities |
-| `src/extrasheet/diff.py` | Core diff engine - compares pristine vs current |
-| `src/extrasheet/request_generator.py` | Generates batchUpdate requests from diff results |
-| `src/extrasheet/pristine.py` | Extracts .pristine/spreadsheet.zip |
-| `src/extrasheet/file_reader.py` | Reads current files from disk |
-| `src/extrasheet/exceptions.py` | Custom exceptions for diff/push |
-| `src/extrasheet/formula_refs.py` | Parses formula references for validation |
-| `src/extrasheet/structural_validation.py` | Validates structural changes (insert/delete rows/cols) |
+| `src/extrasheet/client.py` | `SheetsClient` orchestration for `pull()`, `diff()`, `push()` |
+| `src/extrasheet/transport.py` | Transport abstraction plus Google/local transports |
+| `src/extrasheet/transformer.py` | API response -> on-disk format |
+| `src/extrasheet/writer.py` | Disk writes |
+| `src/extrasheet/diff.py` | Pristine/current diff engine |
+| `src/extrasheet/request_generator.py` | Diff -> Sheets `batchUpdate` requests |
+| `src/extrasheet/comments.py` | `comments.json` conversion and comment diffing |
+| `src/extrasheet/file_reader.py` | Reads editable files from disk |
+| `src/extrasheet/structural_validation.py` | Validation for row/column and sheet structure changes |
 
 ## Documentation
 
-**For Engineers:**
-- `docs/architecture.md` - System overview and design decisions
-- `docs/on-disk-format.md` - Complete file format specification
-- `docs/diff-push-spec.md` - Diff/push implementation details
-
-**For LLM Agents:**
-- `docs/agent-guide/SKILL.md` - Start here: workflow, common operations
-- `docs/agent-guide/formatting.md` - Conditional formats, merges, rich text
-- `docs/agent-guide/features.md` - Charts, pivot tables, filters, validation
-- `docs/agent-guide/batchupdate.md` - Direct API operations (sort, move)
+- `docs/on-disk-format.md` - Canonical file layout and field reference
+- `docs/architecture.md` - System overview
+- `docs/diff-push-spec.md` - What push currently supports
+- `docs/gaps.md` - Pull-only and partially supported areas
 
 ## Key Gotchas
 
-**A1 notation everywhere:** All ranges, cell references, and positions use A1 notation (e.g., `"A1:B5"`, `"F1"`). This includes:
-- `format.json` merges: `{"range": "K50:L51"}`
-- `tables.json` range and column letters: `{"range": "A1:J47", "columnProperties": [{"column": "A", ...}]}`
-- `filters.json` / `banded-ranges.json` ranges: `{"range": "A1:J47"}`
-- `charts.json` anchor cells and source ranges: `{"anchorCell": "F1", "range": "A2:A13"}`
-- `dimension.json` uses column letters and 1-based rows: `{"column": "A", "pixelSize": 180}`, `{"row": 5, "pixelSize": 40}`
-- The diff engine automatically converts A1 notation to 0-based indices when generating API requests.
+- `extrasheet` is a library package. The CLI is `extrasuite sheet ...`, not a
+  standalone `extrasheet` command.
+- `spreadsheet.json` is the entry point for agents. It includes previews and, if
+  a pull was row-limited, `_truncationWarning` plus per-sheet `truncation`.
+- Empty GRID sheets still get an empty `data.tsv` and `{}` `formula.json`.
+- `comments.json` is per-sheet. Only replies and resolution are supported; new
+  top-level comments are not.
+- Several files are pull-only today: `theme.json`,
+  `developer_metadata.json`, `data_sources.json`, `protection.json`, and the
+  grouping/developer-metadata sections inside `dimension.json`.
+- Spreadsheet push only honors `properties.title` at the spreadsheet level.
+  `locale`, `autoRecalc`, and `timeZone` are informational.
+- Sheet push currently honors title, hidden, right-to-left, tab color, and
+  frozen row/column counts from `spreadsheet.json`.
+- Re-pull after every push. `.pristine/spreadsheet.zip` is not auto-updated.
 
-**Color format:** All colors use hex strings (`"#FF0000"`). This applies everywhere: `formatRules`, `conditionalFormats`, `textFormatRuns`, `bandedRanges`, `theme.json`.
-
-**Conditional format ruleIndex:** Optional. If omitted, auto-assigned during diff.
-
-**Pristine state:** Not updated after push. Always re-pull before making additional changes.
-
-See `docs/on-disk-format.md` for complete file format specification.
-
-## CLI Interface
+## CLI Workflow
 
 ```bash
-# Download a spreadsheet to local folder
-./extrasuite sheet pull <spreadsheet_url_or_id> [output_dir]
-# Output: ./<spreadsheet_id>/ or specified output_dir
-
-# Options:
-#   --max-rows N   Maximum rows per sheet (default: 100)
-#   --no-limit     Fetch all rows (may timeout on large spreadsheets)
-#   --no-raw       Don't save raw API responses to .raw/ folder
-
-# Preview changes (dry run)
-./extrasuite sheet diff <folder>
-# Output: batchUpdate JSON to stdout
-
-# Apply changes to Google Sheets
-./extrasuite sheet push <folder>
-# Output: Success message with number of changes applied
-
-# Execute batchUpdate requests directly (for structural changes)
-./extrasuite sheet batchUpdate <spreadsheet_url_or_id> <requests.json>
-# Options:
-#   -v, --verbose  Print API response
+uv run --project client extrasuite sheet pull <url> [output_dir]
+uv run --project client extrasuite sheet diff <folder>
+uv run --project client extrasuite sheet push <folder>
+uv run --project client extrasuite sheet batchUpdate <url> <requests.json>
 ```
 
 ## Folder Structure
 
-After `pull`, the folder contains:
-```
+```text
 <spreadsheet_id>/
-  spreadsheet.json        # Metadata + sheet index + data previews (first 5 / last 3 rows)
-  theme.json              # Default formatting and theme colors (optional)
-  named_ranges.json       # Named ranges (optional)
+  spreadsheet.json
+  theme.json                     # optional, informational
+  named_ranges.json              # optional, editable
+  developer_metadata.json        # optional, informational
+  data_sources.json              # optional, informational
   <sheet_name>/
-    data.tsv              # Cell values
-    formula.json          # Formulas (compressed)
-    format.json           # Formatting (compressed)
-    dimension.json        # Row/column sizes (optional)
-    charts.json           # Embedded charts (optional)
-    pivot-tables.json     # Pivot tables (optional)
-    tables.json           # Structured tables (optional)
-    filters.json          # Basic filter + filter views (optional)
-    banded-ranges.json    # Alternating row/column colors (optional)
-    data-validation.json  # Input validation rules (optional)
-    slicers.json          # Slicers for filtering (optional, rare)
-    data-source-tables.json  # Data source tables (optional, rare)
+    data.tsv
+    formula.json
+    format.json                  # optional
+    dimension.json               # optional
+    charts.json                  # optional
+    pivot-tables.json            # optional
+    tables.json                  # optional
+    filters.json                 # optional
+    banded-ranges.json           # optional
+    data-validation.json         # optional
+    slicers.json                 # optional
+    data-source-tables.json      # optional
+    protection.json              # optional, informational
+    comments.json                # optional, replies/resolve only
   .raw/
-    metadata.json         # Raw metadata API response
-    data.json             # Raw data API response (with grid data)
+    metadata.json
+    data.json
   .pristine/
-    spreadsheet.zip       # Original state for diff comparison
-```
-
-**Progressive disclosure:** LLM agents should start by reading `spreadsheet.json` to understand the structure. The `preview` field in each sheet shows first 5 and last 3 rows, giving agents enough context to decide which sheets need detailed examination.
-
-The agent edits files in place. `diff` and `push` compare against `.pristine/` to determine changes.
-
-## Development
-
-```bash
-cd extrasheet
-uv sync --all-extras
-uv run pytest tests/ -v
-uv run ruff check . && uv run ruff format .
-uv run mypy src/extrasheet
+    spreadsheet.zip
 ```
 
 ## Testing
 
-Tests are in `tests/` and focus on:
-- `test_transformer.py` - API response to on-disk format transformation
-- `test_formula_compression.py` - Formula compression/decompression
-- `test_utils.py` - A1 notation parsing
-- `test_pull_integration.py` - End-to-end pull tests using golden files
-- `test_diff.py` - Diff engine unit tests
-- `test_request_generator.py` - Request generation tests
-- `test_formula_refs.py` - Formula reference parsing for validation
-- `test_structural_validation.py` - Structural change validation tests
-
-### Golden File Testing
-
-Golden files enable testing without mocking or making real API calls:
-
-```
-tests/golden/
-  <spreadsheet_id>/
-    metadata.json    # First API call response (metadata only)
-    data.json        # Second API call response (with grid data)
-```
-
-Use `LocalFileTransport` in tests:
-
-```python
-from extrasheet import SheetsClient, LocalFileTransport
-
-@pytest.fixture
-def client():
-    transport = LocalFileTransport(Path("tests/golden"))
-    return SheetsClient(transport)
-
-@pytest.mark.asyncio
-async def test_pull(client, tmp_path):
-    files = await client.pull("basic_spreadsheet", tmp_path)
-    assert (tmp_path / "basic_spreadsheet" / "Sheet1" / "data.tsv").exists()
-```
-
-### Creating New Golden Files
-
-1. Create a Google Sheets file with the features to test
-2. Pull it: `./extrasuite sheet pull <url>` (raw files saved by default)
-3. Copy `.raw/metadata.json` and `.raw/data.json` to `tests/golden/<name>/`
-4. Verify the output looks correct
-5. Commit the golden files
-
-## Architecture Notes
-
-### Transport-Based Design
-
-```
-┌─────────────────┐     ┌──────────────────┐     ┌─────────────────┐
-│ SheetsClient    │────▶│ Transport        │────▶│ Google API /    │
-│ (orchestration) │     │ (data fetching)  │     │ Local Files     │
-└─────────────────┘     └──────────────────┘     └─────────────────┘
-```
-
-- `Transport` is an abstract base class with `get_metadata()`, `get_data()`, `batch_update()`, `close()`
-- `GoogleSheetsTransport` - Production: makes real API calls via `httpx`
-- `LocalFileTransport` - Testing: reads from local golden files
-- Access token is a transport concern, not a client concern
-
-### Pull Flow
-
-1. **Metadata fetch** - `transport.get_metadata()` gets sheet names and dimensions
-2. **Data fetch** - `transport.get_data()` gets cell contents with row limits
-3. **Transform** - `SpreadsheetTransformer` converts API response to file format
-4. **Write** - `FileWriter` writes TSV/JSON files to disk
-5. **Save raw** - Optionally save `.raw/metadata.json` and `.raw/data.json`
-6. **Pristine copy** - Create `.pristine/spreadsheet.zip` for diff/push
-
-### Key Design Decisions
-
-- **Async-first**: All transport and client methods are async
-- **Two API calls always**: Metadata first, then data with ranges
-- **max_rows=100 default**: Prevents timeout on large spreadsheets
-- **save_raw=True default**: Always saves raw responses for debugging/testing
-- **No mocking in tests**: Use `LocalFileTransport` with golden files instead
-
-### Dependencies
-
-- `httpx` - Async HTTP client for API calls
-- `certifi` - SSL certificates
-- `keyring` - OS keyring for token caching (via credentials.py)
-
-### Diff/Push Flow
-
-1. **Extract pristine** - `pristine.extract_pristine()` extracts `.pristine/spreadsheet.zip`
-2. **Read current** - `file_reader.read_current_files()` reads edited files
-3. **Diff** - `diff.diff()` compares and returns `DiffResult`
-4. **Generate requests** - `request_generator.generate_requests()` converts to batchUpdate JSON
-5. **Push** - `transport.batch_update()` sends to Google Sheets API
-
-### Declarative vs Imperative Workflow
-
-**Declarative (diff/push):** Edit files locally, then push. Works for almost everything:
-- Cell value changes
-- Formula changes (single cells and ranges with autoFill)
-- Sheet/spreadsheet property changes
-- Insert/delete rows/columns (with validation - see below)
-- Delete sheets (with validation)
-- All formatting and feature changes
-
-**Structural Change Validation:**
-When structural changes (insert/delete rows/columns, delete sheets) are detected, the diff engine validates them:
-- **BLOCK:** Formula edits + structural changes that conflict = silent bug prevention. Push fails.
-- **WARN:** Structural changes that break existing formulas (will show #REF! in cells). Use `--force` to proceed.
-- **SILENT:** Ambiguous but valid cases (e.g., appending rows beyond a formula's range). Proceeds without comment.
-
-**Imperative (batchUpdate):** Use direct batchUpdate for complex operations that require precise control:
-- Complex multi-step structural changes
-- Sorting data
-- Moving rows/columns
-
-## Current Status
-
-All core functionality is implemented:
-- `pull` - Downloads spreadsheet to local files
-- `diff` - Compares current vs pristine, outputs batchUpdate JSON
-- `push` - Applies changes to Google Sheets
-- `batchUpdate` - Executes raw batchUpdate requests
-
-**Supported change types:**
-- New sheet creation (add folder + entry in spreadsheet.json, diff/push will create it)
-- Delete sheets (remove folder from disk, validated for cross-sheet references)
-- Insert/delete rows (edit data.tsv, validated for formula conflicts)
-- Insert/delete columns (edit data.tsv, validated for formula conflicts)
-- Cell value changes (add, modify, delete)
-- Formula changes (single cells and ranges with autoFill)
-- Format rules (backgroundColor, numberFormat, textFormat, alignment)
-- Column/row dimensions (width/height changes)
-- Sheet/spreadsheet properties (title, frozen rows/columns, hidden)
-- Data validation (dropdowns, checkboxes, etc.)
-- textFormatRuns (rich text formatting within cells)
-- Cell notes
-- Cell merges
-- Conditional formatting (add, update, delete rules)
-- Basic filters (set, clear)
-- Banded ranges (alternating row/column colors)
-- Filter views (add, update, delete)
-- Charts (add, update spec, update position, delete)
-- Pivot tables (add, modify, delete)
-- Tables (add, update, delete)
-- Named ranges (add, update, delete)
-- Slicers (add, update spec, update position, delete)
-- Data source tables (refresh only - add/delete not supported via API)
+Use the golden-file workflow in `tests/` and prefer verifying format claims
+against `transformer.py`, `diff.py`, `request_generator.py`, and a real pull if
+the docs are in question.

--- a/extrasheet/README.md
+++ b/extrasheet/README.md
@@ -4,138 +4,114 @@ File-based Google Sheets representation library for LLM agents.
 
 ## Overview
 
-`extrasheet` transforms Google Sheets into a file-based representation optimized for LLM agents. Instead of working with complex API responses, agents interact with simple files:
+`extrasheet` pulls a spreadsheet into a small set of TSV and JSON files that are
+easier for humans and agents to inspect than raw Google Sheets API responses.
+The current on-disk format uses:
 
-- **data.tsv** - Cell values in tab-separated format (formulas show computed values)
-- **formula.json** - Sparse dictionary mapping cell coordinates to formulas
-- **format.json** - Cell formatting definitions
-- **feature.json** - Advanced features (charts, pivot tables, filters, etc.)
+- `spreadsheet.json` for spreadsheet metadata, sheet list, previews, and
+  truncation hints
+- `data.tsv` for cell values
+- `formula.json` for formulas
+- `format.json` for cell formatting, merges, notes, and rich text runs
+- Separate feature files such as `charts.json`, `filters.json`,
+  `pivot-tables.json`, and `data-validation.json`
+- Optional per-sheet `comments.json` files for Google Drive comments
 
-This separation allows LLM agents to selectively load only the data they need, reducing token usage and enabling efficient "fly-blind" editing.
+Some pulled files are informational only today and are not diffed or pushed
+back. See [docs/gaps.md](docs/gaps.md).
 
-## Installation
-
-```bash
-pip install extrasheet
-```
-
-Or with uv:
-
-```bash
-uv add extrasheet
-```
-
-## Quick Start
+## Python Usage
 
 ```python
 import asyncio
-from extrasheet import SheetsClient, GoogleSheetsTransport
+from extrasheet import GoogleSheetsTransport, SheetsClient
 
-async def main():
-    # Create transport with access token
+
+async def main() -> None:
     transport = GoogleSheetsTransport(access_token="your_token")
-
-    # Initialize client with transport
     client = SheetsClient(transport)
 
-    # Pull spreadsheet to local files
-    files = await client.pull(
-        "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms",
-        "./output",
-        max_rows=100,      # Default: 100 rows per sheet
-        save_raw=True,     # Default: saves raw API responses
-    )
+    try:
+        await client.pull(
+            "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms",
+            "./output",
+            max_rows=100,
+            save_raw=True,
+        )
+    finally:
+        await transport.close()
 
-    # Clean up
-    await transport.close()
 
 asyncio.run(main())
+```
 
-# Files created:
-# ./output/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms/
-#   ├── spreadsheet.json     # Spreadsheet metadata
-#   ├── Sheet1/
-#   │   ├── data.tsv         # Cell values
-#   │   ├── formula.json     # Cell formulas
-#   │   ├── format.json      # Cell formatting
-#   │   └── feature.json     # Charts, pivot tables, etc.
-#   ├── .raw/
-#   │   ├── metadata.json    # Raw metadata API response
-#   │   └── data.json        # Raw data API response
-#   └── .pristine/
-#       └── spreadsheet.zip  # Pristine copy for diff/push
+Typical output:
+
+```text
+./output/<spreadsheet_id>/
+  spreadsheet.json
+  theme.json                     # optional, informational
+  named_ranges.json              # optional, editable
+  developer_metadata.json        # optional, informational
+  data_sources.json              # optional, informational
+  <sheet_folder>/
+    data.tsv
+    formula.json
+    format.json                  # optional
+    dimension.json               # optional
+    charts.json                  # optional
+    pivot-tables.json            # optional
+    tables.json                  # optional
+    filters.json                 # optional
+    banded-ranges.json           # optional
+    data-validation.json         # optional
+    slicers.json                 # optional
+    data-source-tables.json      # optional
+    protection.json              # optional, informational
+    comments.json                # optional, replies/resolve only
+  .raw/
+    metadata.json                # optional, saved unless save_raw=False
+    data.json
+  .pristine/
+    spreadsheet.zip
 ```
 
 ## CLI Usage
 
+`extrasheet` is the library package. The CLI lives in `extrasuite`:
+
 ```bash
-# Pull a spreadsheet to local files (defaults to ./<spreadsheet_id>/)
-python -m extrasheet pull <spreadsheet_url_or_id> [output_dir]
-
-# Limit rows fetched per sheet (default: 100)
-python -m extrasheet pull <url> --max-rows 500
-
-# Fetch all rows (may timeout on large spreadsheets)
-python -m extrasheet pull <url> --no-limit
-
-# Don't save raw API responses
-python -m extrasheet pull <url> --no-raw
+extrasuite sheet pull <url> [output_dir]
+extrasuite sheet diff <folder>
+extrasuite sheet push <folder>
+extrasuite sheet batchUpdate <url> <requests.json>
 ```
 
-## Architecture
+Inside this repo you can run the local CLI with:
 
-The library uses a transport-based architecture for clean separation of concerns:
-
-```
-┌─────────────────┐     ┌──────────────────┐     ┌─────────────────┐
-│ SheetsClient    │────▶│ Transport        │────▶│ Google API /    │
-│ (orchestration) │     │ (data fetching)  │     │ Local Files     │
-└─────────────────┘     └──────────────────┘     └─────────────────┘
-        │
-        ▼
-┌─────────────────┐     ┌──────────────────┐
-│ Transformer     │────▶│ FileWriter       │
-│ (API → files)   │     │ (disk I/O)       │
-└─────────────────┘     └──────────────────┘
+```bash
+uv run --project client extrasuite sheet pull <url>
 ```
 
-**Transport implementations:**
-- `GoogleSheetsTransport` - Production transport using Google Sheets API
-- `LocalFileTransport` - Test transport reading from local golden files
+## Notes
 
-## Testing with Golden Files
-
-The library supports golden file testing without mocking:
-
-```python
-import pytest
-from pathlib import Path
-from extrasheet import SheetsClient, LocalFileTransport
-
-@pytest.fixture
-def client():
-    transport = LocalFileTransport(Path("tests/golden"))
-    return SheetsClient(transport)
-
-@pytest.mark.asyncio
-async def test_pull(client, tmp_path):
-    files = await client.pull("my_spreadsheet", tmp_path)
-    assert (tmp_path / "my_spreadsheet" / "Sheet1" / "data.tsv").exists()
-```
-
-Golden files are stored as:
-```
-tests/golden/
-  my_spreadsheet/
-    metadata.json    # First API call response
-    data.json        # Second API call response
-```
+- `pull` always fetches metadata first, then grid data with the requested row
+  limit.
+- `comments.json` is fetched separately through the Drive API and written per
+  sheet when comments exist.
+- `.pristine/spreadsheet.zip` is the baseline used by `diff` and `push`.
+- After any successful `push`, re-pull before editing again. `.pristine` is not
+  updated in place.
 
 ## Documentation
 
-- **[On-Disk Format](docs/on-disk-format.md)** - Complete specification of the file format
-- **[LLM Agent Guide](docs/llm-agent-guide.md)** - How to use extrasheet output for spreadsheet modifications
-- **[API Types](src/extrasheet/api_types.py)** - TypedDict definitions generated from Google Sheets API
+- [docs/on-disk-format.md](docs/on-disk-format.md) - Current file layout and
+  field reference
+- [docs/architecture.md](docs/architecture.md) - Implementation overview
+- [docs/diff-push-spec.md](docs/diff-push-spec.md) - What diff/push actually
+  honors
+- [docs/gaps.md](docs/gaps.md) - Current pull-only and partially supported
+  areas
 
 ## Development
 
@@ -150,8 +126,4 @@ uv run mypy src/extrasheet
 
 ## License
 
-MIT License - see [LICENSE](LICENSE) for details.
-
-## Part of ExtraSuite
-
-This package is part of the [ExtraSuite](https://github.com/think41/extrasuite) project, which provides AI agents with secure access to Google Workspace files.
+MIT License - see [LICENSE](LICENSE).

--- a/extrasheet/docs/architecture.md
+++ b/extrasheet/docs/architecture.md
@@ -1,124 +1,108 @@
 # ExtraSheet Architecture
 
-Technical overview for engineers working on or integrating with ExtraSheet.
+Technical overview of the current `extrasheet` implementation.
 
 ## Overview
 
-ExtraSheet transforms Google Sheets into a file-based representation optimized for LLM agents. Instead of working with the verbose Google Sheets API, agents interact with simple local files (TSV, JSON) that can be diffed and pushed back.
+`extrasheet` sits between Google Sheets APIs and a local file representation used
+by `extrasuite sheet`. The design goal is progressive disclosure: agents should
+be able to start with `spreadsheet.json`, then load only the files needed for a
+task.
 
+```text
+SheetsClient
+  -> Transport (metadata, grid data, Drive comments, batchUpdate)
+  -> SpreadsheetTransformer
+  -> FileWriter
+  -> .pristine snapshot for diff/push
 ```
-┌─────────────────┐     ┌──────────────────┐     ┌─────────────────┐
-│ SheetsClient    │────▶│ Transport        │────▶│ Google Sheets   │
-│ (orchestration) │     │ (data fetching)  │     │ API             │
-└─────────────────┘     └──────────────────┘     └─────────────────┘
-        │
-        ▼
-┌─────────────────┐     ┌──────────────────┐
-│ Transformer     │────▶│ Local Files      │
-│ (API → Files)   │     │ (TSV, JSON)      │
-└─────────────────┘     └──────────────────┘
-```
-
-## Core Workflow
-
-```bash
-extrasheet pull <url>      # API → Local files
-# ... agent edits files ...
-extrasheet diff <folder>   # Compare against .pristine, output batchUpdate JSON
-extrasheet push <folder>   # Apply changes via batchUpdate API
-```
-
-## Key Components
-
-| Component | File | Purpose |
-|-----------|------|---------|
-| SheetsClient | `client.py` | Main interface: `pull()`, `diff()`, `push()` |
-| Transport | `transport.py` | Abstract data fetching (Google API or local files) |
-| Transformer | `transformer.py` | Converts API response to on-disk format |
-| FileWriter | `writer.py` | Writes transformed data to disk |
-| Diff Engine | `diff.py` | Compares pristine vs current state |
-| RequestGenerator | `request_generator.py` | Generates batchUpdate requests from diff |
 
 ## Pull Flow
 
-1. **Metadata fetch** — `transport.get_metadata()` gets sheet names and dimensions
-2. **Data fetch** — `transport.get_data()` gets cell contents (with configurable row limits)
-3. **Transform** — `SpreadsheetTransformer` converts API response to file format
-4. **Write** — `FileWriter` writes TSV/JSON files to disk
-5. **Pristine copy** — Creates `.pristine/spreadsheet.zip` for diff comparison
+`SheetsClient.pull()` does the following:
+
+1. Fetch spreadsheet metadata without grid data.
+2. Fetch grid data with the configured row limit.
+3. Transform the API payload into `spreadsheet.json`, sheet files, and optional
+   root-level files.
+4. Write `.raw/metadata.json` and `.raw/data.json` unless `save_raw=False`.
+5. Fetch Drive comments and write per-sheet `comments.json` files when present.
+6. Zip the canonical pulled files into `.pristine/spreadsheet.zip`.
+
+Important details:
+
+- `spreadsheet.json` includes sheet previews and truncation metadata.
+- Empty GRID sheets still produce an empty `data.tsv` and `{}` `formula.json`.
+- Non-GRID sheets do not get `data.tsv` or `formula.json`; they may still emit
+  feature files.
+
+## On-Disk Model
+
+Editable files in the declarative workflow:
+
+- `spreadsheet.json`
+- `data.tsv`
+- `formula.json`
+- `format.json`
+- `dimension.json` for row/column size and hidden state
+- `charts.json`
+- `pivot-tables.json`
+- `tables.json`
+- `filters.json`
+- `banded-ranges.json`
+- `data-validation.json`
+- `slicers.json`
+- `data-source-tables.json` with limited support
+- `named_ranges.json`
+- `comments.json` with limited support
+
+Pulled but currently informational:
+
+- `theme.json`
+- `developer_metadata.json`
+- `data_sources.json`
+- `protection.json`
+- `rowGroups`, `columnGroups`, and `developerMetadata` inside `dimension.json`
+- Spreadsheet-level `locale`, `autoRecalc`, and `timeZone`
 
 ## Diff/Push Flow
 
-1. **Extract pristine** — `pristine.extract_pristine()` extracts `.pristine/spreadsheet.zip`
-2. **Read current** — `file_reader.read_current_files()` reads edited files
-3. **Diff** — `diff.diff()` compares and returns `DiffResult`
-4. **Validate** — Structural changes are validated for formula conflicts
-5. **Generate requests** — `request_generator.generate_requests()` converts to batchUpdate JSON
-6. **Push** — `transport.batch_update()` sends to Google Sheets API
+`SheetsClient.diff()` and `SheetsClient.push()` use the pulled zip as the source
+of truth for the original state.
 
-## Design Decisions
+1. Read `.pristine/spreadsheet.zip`.
+2. Read the current working files from disk.
+3. Validate structural edits such as row/column insertions or deletions.
+4. Diff spreadsheet metadata, sheet properties, cell data, formulas, formats,
+   notes, rich text runs, dimensions, split feature files, and named ranges.
+5. Generate Google Sheets `batchUpdate` requests.
+6. Diff `comments.json` separately and apply comment replies/resolution through
+   the Drive API after the Sheets requests succeed.
 
-**Async-first:** All transport and client methods are async for efficient I/O.
+Actual spreadsheet-level push support is intentionally narrower than pull:
 
-**Two API calls always:** Metadata first (to get sheet dimensions), then data with specific ranges. This allows row limiting without fetching everything.
+- Spreadsheet: title only
+- Sheet properties: title, hidden, right-to-left, tab color, frozen rows, frozen
+  columns
+- Structure: new/delete sheet, insert/delete rows, insert/delete columns
 
-**Transport abstraction:** `GoogleSheetsTransport` for production, `LocalFileTransport` for testing with golden files. No mocking needed.
+## Why The Format Is Split
 
-**Declarative over imperative:** Most operations work by editing local files and pushing. Only complex operations (sort, move) require direct batchUpdate calls.
+- `spreadsheet.json` stays small enough to inspect first.
+- `data.tsv` is compact and easy to diff.
+- `formula.json` keeps formulas separate from displayed values.
+- `format.json` avoids forcing every task to load formatting data.
+- Split feature files avoid the old monolithic `feature.json` while still
+  remaining backward-compatible in the diff engine.
 
-**Formula compression:** Contiguous cells with the same formula pattern are stored as ranges (e.g., `"C2:C100": "=A2+B2"`). Relative references auto-increment on push.
+## Current Boundaries
 
-**Format compression:** Cell formats are stored as range-based rules, not per-cell. Reduces file size and makes bulk formatting changes easier.
+- Theme/default format changes are not pushed.
+- Protection and developer metadata are not pushed.
+- Data source metadata is not pushed; data source tables only support refresh-
+  style updates.
+- Comments cannot be created from scratch because Sheets comments do not expose a
+  stable A1-based anchor model through the public APIs used here.
 
-## File Format
-
-The on-disk format is designed for:
-- Human readability (TSV for data, JSON for structure)
-- LLM comprehension (progressive disclosure via `spreadsheet.json` previews)
-- Efficient diffing (range-based compression, stable ordering)
-
-See **[on-disk-format.md](on-disk-format.md)** for the complete specification.
-
-## Diff/Push Implementation
-
-The diff engine handles:
-- Cell value changes (add, modify, delete)
-- Formula changes (single cells and ranges with autoFill)
-- Format rule changes
-- Structural changes (insert/delete rows/columns, create/delete sheets)
-- Feature changes (charts, pivot tables, filters, etc.)
-
-Structural change validation prevents silent bugs:
-- **BLOCK:** Formula edits + conflicting structural changes
-- **WARN:** Structural changes that break existing formulas (use `--force`)
-
-See **[diff-push-spec.md](diff-push-spec.md)** for implementation details.
-
-## Known Issues
-
-**Color formats:** `formatRules` uses hex strings, but `conditionalFormats` and other sections use RGB dicts. Mixing them causes `'dict' object has no attribute 'lstrip'`.
-
-**Pristine state:** Not auto-updated after push. Always re-pull before making additional changes.
-
-**Sheet IDs:** Google may reassign IDs when creating sheets. Re-pull to get server-assigned IDs.
-
-**Error messages:** The error `'dict' object has no attribute 'lstrip'` can mean several different things (wrong color format, wrong JSON structure, etc.).
-
-## Testing
-
-Tests use golden files instead of mocks:
-
-```
-tests/golden/
-  <spreadsheet_id>/
-    metadata.json    # First API call response
-    data.json        # Second API call response
-```
-
-`LocalFileTransport` reads from these files, enabling deterministic testing without API calls.
-
-## Related Documentation
-
-- **[on-disk-format.md](on-disk-format.md)** — Complete file format specification
-- **[diff-push-spec.md](diff-push-spec.md)** — Diff/push implementation details
-- **[agent-guide/](agent-guide/)** — LLM-focused usage guides
+See [on-disk-format.md](on-disk-format.md) for the file reference and
+[diff-push-spec.md](diff-push-spec.md) for the exact editable surface.

--- a/extrasheet/docs/diff-push-spec.md
+++ b/extrasheet/docs/diff-push-spec.md
@@ -1,1255 +1,213 @@
 # Extrasheet Diff/Push Specification
 
-Version: 1.0.0
-Last Updated: 2026-01-28
+Version: 2.0
+Last Updated: 2026-03-06
 
-## Overview
+This document describes what the current `extrasheet` diff/push path actually
+reads, diffs, and sends back to Google.
 
-This document specifies how extrasheet compares edited files against the pristine copy and generates Google Sheets API `batchUpdate` requests to apply changes.
+## High-Level Flow
 
-## Table of Contents
-
-1. [High-Level Architecture](#high-level-architecture)
-2. [Google Sheets batchUpdate Operations](#google-sheets-batchupdate-operations)
-3. [File Change to Operation Mapping](#file-change-to-operation-mapping)
-4. [Formula Invalidation Problem](#formula-invalidation-problem)
-5. [Diff Algorithm](#diff-algorithm)
-6. [Request Generation](#request-generation)
-7. [Operation Ordering](#operation-ordering)
-8. [Supported vs Unsupported Operations](#supported-vs-unsupported-operations)
-
----
-
-## High-Level Architecture
-
-```
-┌─────────────────────────────────────────────────────────────────────────┐
-│                           DIFF/PUSH FLOW                                │
-├─────────────────────────────────────────────────────────────────────────┤
-│                                                                         │
-│  .pristine/spreadsheet.zip          Current Files                       │
-│         │                                │                              │
-│         ▼                                ▼                              │
-│  ┌─────────────┐                 ┌─────────────┐                        │
-│  │ Extract &   │                 │ Read from   │                        │
-│  │ Parse       │                 │ Disk        │                        │
-│  └──────┬──────┘                 └──────┬──────┘                        │
-│         │                                │                              │
-│         ▼                                ▼                              │
-│  ┌─────────────────────────────────────────────┐                        │
-│  │              DIFF ENGINE                     │                        │
-│  │  - Compare spreadsheet.json (sheet changes) │                        │
-│  │  - Compare data.tsv (cell values)           │                        │
-│  │  - Compare formula.json (formulas)          │                        │
-│  │  - Compare format.json (formatting)         │                        │
-│  │  - Compare feature.json (charts, etc.)      │                        │
-│  │  - Compare dimension.json (row/col sizes)   │                        │
-│  └──────────────────┬──────────────────────────┘                        │
-│                     │                                                   │
-│                     ▼                                                   │
-│  ┌─────────────────────────────────────────────┐                        │
-│  │           REQUEST GENERATOR                  │                        │
-│  │  - Convert changes to batchUpdate requests  │                        │
-│  │  - Order requests correctly                 │                        │
-│  │  - Validate no formula-breaking changes     │                        │
-│  └──────────────────┬──────────────────────────┘                        │
-│                     │                                                   │
-│                     ▼                                                   │
-│  ┌─────────────────────────────────────────────┐                        │
-│  │          batchUpdate JSON                    │                        │
-│  │  (diff outputs this, push sends to API)     │                        │
-│  └─────────────────────────────────────────────┘                        │
-│                                                                         │
-└─────────────────────────────────────────────────────────────────────────┘
+```text
+.pristine/spreadsheet.zip + current files
+  -> structural validation
+  -> diff
+  -> batchUpdate request generation
+  -> Sheets API
+  -> Drive comment operations (replies/resolution only)
 ```
 
----
-
-## Google Sheets batchUpdate Operations
-
-The Google Sheets API provides 69 batchUpdate operations organized into categories:
-
-### Cell Data (5 operations)
-| Operation | Description | Extrasheet Support |
-|-----------|-------------|-------------------|
-| `updateCells` | Updates cells in a range with new data | **Primary** - for values, formulas, formats |
-| `repeatCell` | Applies same cell data to a range | Supported - for bulk formatting |
-| `appendCells` | Adds cells after last row with data | Supported - for appending data |
-| `mergeCells` | Merges cells in a range | Supported |
-| `unmergeCells` | Unmerges cells in a range | Supported |
-
-### Rows & Columns (10 operations)
-| Operation | Description | Extrasheet Support |
-|-----------|-------------|-------------------|
-| `appendDimension` | Adds rows/columns at the end | **Safe** - doesn't shift formulas |
-| `insertDimension` | Inserts rows/columns at index | **Supported** - runs LAST after all content changes |
-| `deleteDimension` | Deletes rows/columns | **Supported** - runs LAST after all content changes |
-| `moveDimension` | Moves rows/columns | **Supported** - runs LAST after all content changes |
-| `updateDimensionProperties` | Updates row/column size, hidden | Supported |
-| `autoResizeDimensions` | Auto-resize based on content | Not supported |
-| `addDimensionGroup` | Creates row/column group | Supported |
-| `deleteDimensionGroup` | Deletes row/column group | Supported |
-| `updateDimensionGroup` | Updates group collapsed state | Supported |
-| `textToColumns` | Splits text column | Not supported |
-
-### Sheet Management (3 operations)
-| Operation | Description | Extrasheet Support |
-|-----------|-------------|-------------------|
-| `addSheet` | Creates new sheet | Supported |
-| `deleteSheet` | Deletes sheet | Supported |
-| `duplicateSheet` | Duplicates sheet | Not supported |
-
-### Sheet Properties (2 operations)
-| Operation | Description | Extrasheet Support |
-|-----------|-------------|-------------------|
-| `updateSheetProperties` | Updates sheet title, hidden, frozen rows/cols | Supported |
-| `updateSpreadsheetProperties` | Updates spreadsheet title, locale, timezone | Supported |
-
-### Formatting (5 operations)
-| Operation | Description | Extrasheet Support |
-|-----------|-------------|-------------------|
-| `updateBorders` | Sets cell borders | Supported |
-| `addConditionalFormatRule` | Adds conditional format | Supported |
-| `deleteConditionalFormatRule` | Deletes conditional format | Supported |
-| `updateConditionalFormatRule` | Updates conditional format | Supported |
-| `updateEmbeddedObjectBorder` | Updates chart/image border | Not supported |
-
-### Named Ranges (3 operations)
-| Operation | Description | Extrasheet Support |
-|-----------|-------------|-------------------|
-| `addNamedRange` | Creates named range | Supported |
-| `deleteNamedRange` | Deletes named range | Supported |
-| `updateNamedRange` | Updates named range | Supported |
-
-### Charts (2 operations)
-| Operation | Description | Extrasheet Support |
-|-----------|-------------|-------------------|
-| `addChart` | Creates chart | Supported |
-| `updateChartSpec` | Updates chart configuration | Supported |
-
-### Filters (6 operations)
-| Operation | Description | Extrasheet Support |
-|-----------|-------------|-------------------|
-| `setBasicFilter` | Sets filter on sheet | Supported |
-| `clearBasicFilter` | Clears filter | Supported |
-| `addFilterView` | Creates filter view | Supported |
-| `deleteFilterView` | Deletes filter view | Supported |
-| `updateFilterView` | Updates filter view | Supported |
-| `duplicateFilterView` | Duplicates filter view | Not supported |
-
-### Data Validation (1 operation)
-| Operation | Description | Extrasheet Support |
-|-----------|-------------|-------------------|
-| `setDataValidation` | Sets validation rule on range | Supported |
-
-### Protection (3 operations)
-| Operation | Description | Extrasheet Support |
-|-----------|-------------|-------------------|
-| `addProtectedRange` | Creates protected range | Supported |
-| `deleteProtectedRange` | Deletes protected range | Supported |
-| `updateProtectedRange` | Updates protected range | Supported |
-
-### Copy & Paste (3 operations)
-| Operation | Description | Extrasheet Support |
-|-----------|-------------|-------------------|
-| `copyPaste` | Copies data between ranges | Not supported |
-| `cutPaste` | Moves data between ranges | Not supported |
-| `pasteData` | Pastes delimited data | Not supported |
-
-### Other Operations
-| Operation | Description | Extrasheet Support |
-|-----------|-------------|-------------------|
-| `autoFill` | Auto-fills data/formula pattern | **Critical** - for formula range updates |
-| `findReplace` | Find and replace text | Not supported |
-| `sortRange` | Sorts data in range | Supported - runs LAST |
-| `deleteDuplicates` | Removes duplicate rows | Not supported |
-| `trimWhitespace` | Trims whitespace | Not supported |
-| `randomizeRange` | Randomizes row order | Not supported |
-| `deleteRange` | Deletes range, shifts cells | **Supported** - runs LAST |
-| `insertRange` | Inserts range, shifts cells | **Supported** - runs LAST |
-
-### Banded Ranges (3 operations)
-| Operation | Description | Extrasheet Support |
-|-----------|-------------|-------------------|
-| `addBanding` | Creates alternating colors | Supported |
-| `deleteBanding` | Deletes banding | Supported |
-| `updateBanding` | Updates banding | Supported |
-
-### Tables (3 operations)
-| Operation | Description | Extrasheet Support |
-|-----------|-------------|-------------------|
-| `addTable` | Creates structured table | Supported |
-| `deleteTable` | Deletes table | Supported |
-| `updateTable` | Updates table | Supported |
-
-### Slicers (2 operations)
-| Operation | Description | Extrasheet Support |
-|-----------|-------------|-------------------|
-| `addSlicer` | Creates slicer | Supported |
-| `updateSlicerSpec` | Updates slicer | Supported |
-
-### Embedded Objects (2 operations)
-| Operation | Description | Extrasheet Support |
-|-----------|-------------|-------------------|
-| `deleteEmbeddedObject` | Deletes chart/image | Supported |
-| `updateEmbeddedObjectPosition` | Moves/resizes chart/image | Supported |
-
-### Developer Metadata (3 operations)
-| Operation | Description | Extrasheet Support |
-|-----------|-------------|-------------------|
-| `createDeveloperMetadata` | Creates app-specific metadata | Supported |
-| `updateDeveloperMetadata` | Updates metadata | Supported |
-| `deleteDeveloperMetadata` | Deletes metadata | Supported |
-
-### Data Sources (5 operations)
-| Operation | Description | Extrasheet Support |
-|-----------|-------------|-------------------|
-| All data source operations | BigQuery/Looker connections | Not supported |
-
----
-
-## Two Workflows: Declarative and Imperative
-
-Extrasheet provides two distinct workflows for modifying spreadsheets:
-
-### Declarative Workflow (pull-diff-push)
-
-The primary workflow for 90% of use cases. Edit files to declare the desired state, then push.
-
-```
-┌─────────┐     ┌─────────┐     ┌─────────┐     ┌─────────┐
-│  pull   │────▶│  edit   │────▶│  diff   │────▶│  push   │
-│         │     │ files   │     │         │     │         │
-└─────────┘     └─────────┘     └─────────┘     └─────────┘
-     │                               │               │
-     ▼                               ▼               ▼
- Downloads          Agent edits   Compares      Applies
- to files           data.tsv,     pristine      changes
-                    formula.json, vs current    to API
-                    format.json
-```
-
-**Characteristics:**
-- **Order-independent**: Changes are detected by comparing states, not tracked sequentially
-- **Idempotent**: Running diff/push multiple times with same files produces same result
-- **Safe**: Cannot accidentally invalidate formulas (dimensions are fixed)
-
-**What you CAN do declaratively:**
-- Modify cell values
-- Add/modify/remove formulas
-- Change formatting (cell formats, conditional formats, borders)
-- Add/modify/remove features (charts, tables, filters, validation, etc.)
-- Update properties (sheet title, frozen rows, hidden state, etc.)
-- Add/modify/remove named ranges
-
-**What you CANNOT do declaratively:**
-- Insert rows/columns
-- Delete rows/columns
-- Move rows/columns
-- Sort data
-
-### Imperative Workflow (explicit commands)
-
-For structural changes that alter the grid dimensions. These are explicit commands.
-
-```
-┌─────────────────┐     ┌─────────────────┐     ┌─────────┐
-│ Imperative      │────▶│ Execute via     │────▶│ re-pull │
-│ commands        │     │ API             │     │         │
-└─────────────────┘     └─────────────────┘     └─────────┘
-        │                       │                    │
-        ▼                       ▼                    ▼
-  insertDimension         Runs immediately      Local files
-  deleteDimension         on Google Sheets      are now stale,
-  moveDimension                                 need refresh
-  sortRange
-```
-
-**Characteristics:**
-- **Order-dependent**: Commands execute in the order specified
-- **Immediate**: Applied directly to Google Sheets API
-- **Invalidates local state**: After execution, local files are stale
-
-**After imperative commands, you MUST:**
-1. Re-pull the spreadsheet to get updated state
-2. Then continue with declarative edits if needed
-
-### Interleaving Workflows
-
-The LLM can interleave declarative and imperative workflows as needed:
-
-```
-Example: Add a new "Status" column between columns B and C
-
-1. [Imperative] Insert column at position C
-   → extrasheet exec insertDimension --dimension=COLUMNS --index=2
-
-2. [Re-pull] Get updated state
-   → extrasheet pull <id>
-
-3. [Declarative] Fill the new column with data and formulas
-   → Edit data.tsv, formula.json
-   → extrasheet push
-```
-
-Or batch multiple imperative operations:
-
-```
-Example: Restructure the sheet
-
-1. [Imperative] Batch structural changes
-   → extrasheet exec --batch commands.json
-   (contains: insertDimension, moveDimension, deleteDimension)
-
-2. [Re-pull] Get updated state
-   → extrasheet pull <id>
-
-3. [Declarative] Make content changes
-   → Edit files, push
-```
-
-### Why Two Workflows?
-
-**Declarative is preferred because:**
-- Simpler mental model (desired state, not steps)
-- Order doesn't matter
-- Easy to review changes before applying
-- Handles 90% of editing tasks
-
-**Imperative is necessary because:**
-- Structural changes shift cell references
-- Google Sheets updates formulas automatically
-- Our local files would have stale coordinates after structural changes
-- Simpler to re-pull than to track coordinate transformations
-
----
-
-## File Change to Operation Mapping
-
-### spreadsheet.json Changes
-
-| Change | API Operation |
-|--------|---------------|
-| `properties.title` changed | `updateSpreadsheetProperties` |
-| `properties.locale` changed | `updateSpreadsheetProperties` |
-| `properties.timeZone` changed | `updateSpreadsheetProperties` |
-| Sheet added (new entry in `sheets[]`) | `addSheet` |
-| Sheet removed | `deleteSheet` |
-| `sheets[].title` changed | `updateSheetProperties` |
-| `sheets[].hidden` changed | `updateSheetProperties` |
-| `sheets[].gridProperties.frozenRowCount` changed | `updateSheetProperties` |
-| `sheets[].gridProperties.frozenColumnCount` changed | `updateSheetProperties` |
-| `sheets[].tabColorStyle` changed | `updateSheetProperties` |
-| `sheets[].index` changed (reorder) | `updateSheetProperties` |
-
-### data.tsv Changes
-
-The data.tsv file contains cell VALUES (formulas show their computed results).
-
-| Change | Detection | Result |
-|--------|-----------|--------|
-| Cell value changed | Cell-by-cell comparison | `updateCells` with `userEnteredValue` |
-| Row count changed | Grid dimension mismatch | **Error**: Use imperative commands |
-| Column count changed | Grid dimension mismatch | **Error**: Use imperative commands |
-
-**Important:** When a cell has a formula (in formula.json), changing data.tsv for that cell is **ignored** - the formula takes precedence.
-
-**Grid dimension validation:** The diff engine validates that grid dimensions match between pristine and current. If dimensions differ, it raises `GridDimensionChangedError`:
-
-```python
-def validate_grid_dimensions(pristine_tsv: str, current_tsv: str) -> None:
-    pristine_grid = parse_tsv(pristine_tsv)
-    current_grid = parse_tsv(current_tsv)
-
-    pristine_rows = len(pristine_grid)
-    current_rows = len(current_grid)
-    pristine_cols = max(len(row) for row in pristine_grid) if pristine_grid else 0
-    current_cols = max(len(row) for row in current_grid) if current_grid else 0
-
-    if pristine_rows != current_rows or pristine_cols != current_cols:
-        raise GridDimensionChangedError(
-            f"Grid dimensions changed from {pristine_rows}x{pristine_cols} "
-            f"to {current_rows}x{current_cols}. "
-            "Use imperative commands (extrasheet exec) for structural changes."
-        )
-```
-
-### formula.json Changes
-
-| Change | Detection Method | API Operation |
-|--------|-----------------|---------------|
-| New single-cell formula | Key present in edited, not in pristine | `updateCells` with `userEnteredValue.formulaValue` |
-| New range formula | Range key present in edited, not in pristine | `updateCells` (first cell) + `autoFill` |
-| Formula removed | Key present in pristine, not in edited | `updateCells` with `userEnteredValue` (value from data.tsv) |
-| Formula modified (single cell) | Same key, different value | `updateCells` with `userEnteredValue.formulaValue` |
-| Formula modified (range) | Same range key, different formula | `updateCells` (first cell) + `autoFill` |
-| Formula range expanded | e.g., "A1:A5" → "A1:A10" | `autoFill` to extend |
-| Formula range contracted | e.g., "A1:A10" → "A1:A5" | `updateCells` to clear removed cells |
-
-**AutoFill for Formula Ranges:**
-
-When a formula is associated with a range (e.g., `"C2:C100": "=A2+B2"`), the most efficient approach is:
-
-1. Update the FIRST cell with the formula using `updateCells`
-2. Use `autoFill` to copy the formula across the entire range
-
-This is far more efficient than sending individual `updateCells` for each cell, and it properly handles relative references.
-
-```python
-def generate_formula_range_requests(
-    range_key: str,
-    formula: str,
-    sheet_id: int,
-) -> list[dict]:
-    """
-    Generate requests for a formula range change.
-
-    Example: "C2:C100": "=A2+B2"
-
-    1. updateCells: Set C2 = "=A2+B2"
-    2. autoFill: Fill from C2 to C2:C100
-    """
-    start_cell, end_cell = parse_range(range_key)
-    start_row, start_col = a1_to_cell(start_cell)
-    end_row, end_col = a1_to_cell(end_cell)
-
-    requests = []
-
-    # 1. Set the formula in the first cell
-    requests.append({
-        "updateCells": {
-            "rows": [{
-                "values": [{
-                    "userEnteredValue": {"formulaValue": formula}
-                }]
-            }],
-            "fields": "userEnteredValue",
-            "start": {
-                "sheetId": sheet_id,
-                "rowIndex": start_row,
-                "columnIndex": start_col,
-            }
-        }
-    })
-
-    # 2. AutoFill to the entire range
-    requests.append({
-        "autoFill": {
-            "useAlternateSeries": False,
-            "sourceAndDestination": {
-                "source": {
-                    "sheetId": sheet_id,
-                    "startRowIndex": start_row,
-                    "endRowIndex": start_row + 1,
-                    "startColumnIndex": start_col,
-                    "endColumnIndex": start_col + 1,
-                },
-                "destination": {
-                    "sheetId": sheet_id,
-                    "startRowIndex": start_row,
-                    "endRowIndex": end_row + 1,
-                    "startColumnIndex": start_col,
-                    "endColumnIndex": end_col + 1,
-                },
-                "fillLength": end_row - start_row,
-            }
-        }
-    })
-
-    return requests
-```
-
-**Why AutoFill is Critical:**
-
-1. **Efficiency**: One API call vs. hundreds of `updateCells`
-2. **Correctness**: Google Sheets handles relative reference adjustment
-3. **Consistency**: Matches how users would manually drag formulas
-
-### format.json Changes
-
-| Change | Detection Method | API Operation |
-|--------|-----------------|---------------|
-| `formatRules` entry added | New range in edited | `repeatCell` or `updateCells` |
-| `formatRules` entry removed | Range in pristine, not in edited | `repeatCell` to clear format |
-| `formatRules` entry modified | Same range, different format | `repeatCell` with new format |
-| `conditionalFormats` added | New index | `addConditionalFormatRule` |
-| `conditionalFormats` removed | Index in pristine, not in edited | `deleteConditionalFormatRule` |
-| `conditionalFormats` modified | Same index, different rule | `updateConditionalFormatRule` |
-| `merges` added | New merge range | `mergeCells` |
-| `merges` removed | Merge in pristine, not in edited | `unmergeCells` |
-| `notes` added/modified | New/changed note | `updateCells` with `note` field |
-| `notes` removed | Note in pristine, not in edited | `updateCells` with empty `note` |
-
-### feature.json Changes
-
-| Change | Detection Method | API Operation |
-|--------|-----------------|---------------|
-| `basicFilter` added | Present in edited, not pristine | `setBasicFilter` |
-| `basicFilter` removed | Present in pristine, not edited | `clearBasicFilter` |
-| `basicFilter` modified | Different filter specs | `setBasicFilter` (replaces) |
-| `dataValidation` added | New validation group | `setDataValidation` |
-| `dataValidation` removed | Group in pristine, not edited | `setDataValidation` with no rule |
-| `dataValidation` modified | Different rule for same cells | `setDataValidation` |
-| `bandedRanges` added | New banded range | `addBanding` |
-| `bandedRanges` removed | Banded range in pristine only | `deleteBanding` |
-| `bandedRanges` modified | Different colors/range | `updateBanding` |
-| `charts` added | New chart | `addChart` |
-| `charts` removed | Chart in pristine only | `deleteEmbeddedObject` |
-| `charts` modified | Different spec | `updateChartSpec` |
-| `tables` added | New table | `addTable` |
-| `tables` removed | Table in pristine only | `deleteTable` |
-| `tables` modified | Different config | `updateTable` |
-| `filterViews` added | New filter view | `addFilterView` |
-| `filterViews` removed | Filter view in pristine only | `deleteFilterView` |
-| `filterViews` modified | Different filter specs | `updateFilterView` |
-| `slicers` added | New slicer | `addSlicer` |
-| `slicers` removed | Slicer in pristine only | `deleteEmbeddedObject` |
-| `slicers` modified | Different spec | `updateSlicerSpec` |
-
-### dimension.json Changes
-
-| Change | Detection Method | API Operation |
-|--------|-----------------|---------------|
-| Row/column size changed | Different `pixelSize` | `updateDimensionProperties` |
-| Row/column hidden | `hidden: true` added | `updateDimensionProperties` |
-| Row/column unhidden | `hidden: true` removed | `updateDimensionProperties` |
-| Row/column group added | New group in groups array | `addDimensionGroup` |
-| Row/column group removed | Group in pristine only | `deleteDimensionGroup` |
-| Group collapsed/expanded | Different `collapsed` value | `updateDimensionGroup` |
-
-### named_ranges.json Changes
-
-| Change | Detection Method | API Operation |
-|--------|-----------------|---------------|
-| Named range added | New name in edited | `addNamedRange` |
-| Named range removed | Name in pristine only | `deleteNamedRange` |
-| Named range modified | Same name, different range | `updateNamedRange` |
-
-### theme.json Changes
-
-| Change | Detection Method | API Operation |
-|--------|-----------------|---------------|
-| `defaultFormat` changed | Different format values | `updateSpreadsheetProperties` |
-| `spreadsheetTheme` changed | Different theme colors | `updateSpreadsheetProperties` |
-
----
-
-## Diff Algorithm
-
-### Phase 1: Load and Parse
-
-```python
-async def diff(folder: Path) -> DiffResult:
-    """
-    Compare current files against pristine copy.
-
-    Returns DiffResult containing all detected changes.
-    """
-    # 1. Extract pristine files from zip
-    pristine = extract_pristine(folder / ".pristine" / "spreadsheet.zip")
-
-    # 2. Load current files
-    current = load_current_files(folder)
-
-    # 3. Parse spreadsheet.json for sheet metadata
-    pristine_meta = json.loads(pristine["spreadsheet.json"])
-    current_meta = json.loads(current["spreadsheet.json"])
-
-    # 4. Build sheet mapping (folder name → sheetId)
-    sheet_mapping = build_sheet_mapping(current_meta)
-
-    # 5. Diff each component
-    result = DiffResult()
-
-    # Spreadsheet-level changes
-    result.spreadsheet_changes = diff_spreadsheet_properties(
-        pristine_meta, current_meta
-    )
-
-    # Sheet-level changes
-    for sheet in current_meta["sheets"]:
-        folder_name = sheet["folder"]
-        sheet_id = sheet["sheetId"]
-
-        result.sheet_changes.append(
-            diff_sheet(
-                pristine, current, folder_name, sheet_id
-            )
-        )
-
-    # Detect structural changes (to be run LAST)
-    result.structural_changes = detect_structural_changes(
-        pristine_meta, current_meta, pristine, current
-    )
-
-    return result
-```
-
-### Phase 2: Cell-Level Diffing
-
-For data.tsv and formula.json, we need to diff at the cell level:
-
-```python
-def diff_sheet_data(
-    pristine_tsv: str,
-    current_tsv: str,
-    pristine_formulas: dict,
-    current_formulas: dict,
-) -> tuple[list[CellChange], list[StructuralChange]]:
-    """
-    Diff cell data between pristine and current.
-
-    Returns:
-        - cell_changes: List of individual cell changes
-        - structural_changes: List of insert/delete/move operations
-    """
-    cell_changes = []
-    structural_changes = []
-
-    # Parse TSV files
-    pristine_grid = parse_tsv(pristine_tsv)
-    current_grid = parse_tsv(current_tsv)
-
-    # Detect structural changes first
-    structural = detect_structural_changes(pristine_grid, current_grid)
-    if structural:
-        structural_changes.extend(structural)
-        # Adjust cell positions based on structural changes
-        # for proper content diffing
-        adjusted_grid = apply_reverse_structural(current_grid, structural)
-    else:
-        adjusted_grid = current_grid
-
-    # Expand formula ranges - DON'T expand to individual cells
-    # Instead, compare ranges directly for efficiency
-    pristine_ranges = pristine_formulas  # Keep as ranges
-    current_ranges = current_formulas
-
-    # Get dimensions (of original pristine coordinates)
-    max_row = len(pristine_grid)
-    max_col = max(len(row) for row in pristine_grid) if pristine_grid else 0
-
-    # Compare each cell using pristine coordinates
-    for row in range(max_row):
-        for col in range(max_col):
-            cell_ref = f"{col_to_letter(col)}{row + 1}"
-
-            pristine_value = get_cell(pristine_grid, row, col)
-            current_value = get_cell(adjusted_grid, row, col)
-
-            # Check if cell is part of a formula range
-            pristine_formula = get_formula_for_cell(pristine_ranges, cell_ref)
-            current_formula = get_formula_for_cell(current_ranges, cell_ref)
-
-            # ... rest of cell comparison logic
-
-    return cell_changes, structural_changes
-```
-
-### Phase 3: Detecting Structural Changes
-
-```python
-def detect_structural_changes(
-    pristine_grid: list[list[str]],
-    current_grid: list[list[str]],
-) -> list[StructuralChange]:
-    """
-    Detect row/column insertions, deletions, and moves.
-
-    Uses heuristics:
-    1. If current has more rows and content shifted down → middle insert
-    2. If current has more columns and content shifted right → middle insert
-    """
-    pristine_rows = len(pristine_grid)
-    current_rows = len(current_grid)
-
-    if current_rows > pristine_rows:
-        # Check if it's an append (new rows at end) or insert (content shifted)
-        # Compare first N rows - if they match, it's an append
-        for i in range(min(pristine_rows, 10)):  # Check first 10 rows
-            if pristine_grid[i] != current_grid[i]:
-                # Content shifted - this is a middle insertion
-                return True
-
-    # Similar check for columns
-    # ...
-
-    return False
-```
-
----
-
-## Request Generation
-
-### Building UpdateCells Requests
-
-The most common operation is `updateCells`. We batch changes into ranges for efficiency:
-
-```python
-def generate_update_cells_requests(
-    changes: list[CellChange],
-    sheet_id: int,
-) -> list[dict]:
-    """
-    Generate updateCells requests from cell changes.
-
-    Groups adjacent cells into ranges for efficiency.
-    """
-    requests = []
-
-    # Group changes by row for row-based batching
-    changes_by_row = group_by_row(changes)
-
-    for row_idx, row_changes in changes_by_row.items():
-        # Build RowData with CellData for each changed cell
-        row_data = build_row_data(row_changes)
-
-        # Find the range this row covers
-        start_col = min(c.col for c in row_changes)
-        end_col = max(c.col for c in row_changes) + 1
-
-        requests.append({
-            "updateCells": {
-                "rows": [row_data],
-                "fields": "userEnteredValue",
-                "range": {
-                    "sheetId": sheet_id,
-                    "startRowIndex": row_idx,
-                    "endRowIndex": row_idx + 1,
-                    "startColumnIndex": start_col,
-                    "endColumnIndex": end_col,
-                }
-            }
-        })
-
-    return requests
-
-
-def build_row_data(changes: list[CellChange]) -> dict:
-    """Build RowData object for updateCells."""
-    # Sort by column
-    changes = sorted(changes, key=lambda c: c.col)
-
-    cells = []
-    for change in changes:
-        cell_data = {}
-
-        if change.change_type == "formula":
-            cell_data["userEnteredValue"] = {
-                "formulaValue": change.new_value
-            }
-        elif change.change_type == "value":
-            # Determine value type
-            cell_data["userEnteredValue"] = infer_value_type(change.new_value)
-
-        cells.append(cell_data)
-
-    return {"values": cells}
-
-
-def infer_value_type(value: str) -> dict:
-    """
-    Infer the ExtendedValue type from a string value.
-
-    Returns appropriate userEnteredValue structure.
-    """
-    if value == "":
-        return {}  # Empty cell
-
-    # Try to parse as number
-    try:
-        num = float(value.replace(",", ""))
-        return {"numberValue": num}
-    except ValueError:
-        pass
-
-    # Check for boolean
-    if value.upper() == "TRUE":
-        return {"boolValue": True}
-    if value.upper() == "FALSE":
-        return {"boolValue": False}
-
-    # Default to string
-    return {"stringValue": value}
-```
-
-### Format Request Generation
-
-```python
-def generate_format_requests(
-    format_changes: list[FormatChange],
-    sheet_id: int,
-) -> list[dict]:
-    """Generate formatting requests from format changes."""
-    requests = []
-
-    for change in format_changes:
-        if change.change_type == "add" or change.change_type == "modify":
-            # Use repeatCell for efficient range formatting
-            requests.append({
-                "repeatCell": {
-                    "range": {
-                        "sheetId": sheet_id,
-                        **a1_to_grid_range(change.range),
-                    },
-                    "cell": {
-                        "userEnteredFormat": change.format
-                    },
-                    "fields": build_format_fields(change.format),
-                }
-            })
-        elif change.change_type == "remove":
-            # Clear formatting by setting to default
-            requests.append({
-                "repeatCell": {
-                    "range": {
-                        "sheetId": sheet_id,
-                        **a1_to_grid_range(change.range),
-                    },
-                    "cell": {
-                        "userEnteredFormat": {}
-                    },
-                    "fields": "userEnteredFormat",
-                }
-            })
-
-    return requests
-```
-
----
-
-## Declarative Diff: Order Independence
-
-In the declarative workflow, the diff engine compares pristine vs current state and generates the minimal set of API requests. Order doesn't matter because we're comparing states, not tracking changes.
-
-### How Diff Works
-
-```python
-def diff(folder: Path) -> DiffResult:
-    """
-    Compare current files against pristine copy.
-
-    Returns changes grouped by type, not ordered.
-    """
-    pristine = extract_pristine(folder / ".pristine" / "spreadsheet.zip")
-    current = load_current_files(folder)
-
-    return DiffResult(
-        cell_changes=diff_cells(pristine, current),
-        formula_changes=diff_formulas(pristine, current),
-        format_changes=diff_formats(pristine, current),
-        feature_changes=diff_features(pristine, current),
-        property_changes=diff_properties(pristine, current),
-    )
-```
-
-### Request Generation
-
-The request generator converts diff results to API requests. While the diff is unordered, requests are batched efficiently:
-
-```python
-def generate_requests(diff: DiffResult) -> list[dict]:
-    """
-    Generate batchUpdate requests from diff.
-
-    Batches changes for efficiency, but conceptually unordered.
-    """
-    requests = []
-
-    # Cell changes → updateCells (batched by row)
-    requests.extend(generate_cell_requests(diff.cell_changes))
-
-    # Formula ranges → updateCells + autoFill
-    requests.extend(generate_formula_requests(diff.formula_changes))
-
-    # Format changes → repeatCell, updateBorders, etc.
-    requests.extend(generate_format_requests(diff.format_changes))
-
-    # Feature changes → add/update/delete operations
-    requests.extend(generate_feature_requests(diff.feature_changes))
-
-    # Property changes → updateSheetProperties, etc.
-    requests.extend(generate_property_requests(diff.property_changes))
-
-    return requests
-```
-
-### No Structural Operations in Declarative Workflow
-
-The declarative workflow **never generates** structural operations:
-- No `insertDimension`
-- No `deleteDimension`
-- No `moveDimension`
-- No `sortRange`
-
-If the diff detects a grid dimension change (more/fewer rows or columns), it raises an error:
-
-```python
-class GridDimensionChangedError(DiffError):
-    """
-    Local files have different grid dimensions than pristine.
-
-    This happens when rows/columns were added/removed from data.tsv.
-    Use imperative commands for structural changes.
-    """
-    pass
-```
-
-## Imperative Workflow: batchUpdate Command
-
-Structural changes use the native Google Sheets batchUpdate format directly.
-
-### CLI Interface
-
-```bash
-# Execute batchUpdate requests from JSON file
-extrasheet batchUpdate <url_or_folder> <requests.json>
-
-# After batchUpdate, re-pull to get updated state
-extrasheet pull <url>
-```
-
-### Request Format
-
-Uses the exact same format as the Google Sheets API - no new syntax to learn:
-
-```json
-{
-  "requests": [
-    {
-      "insertDimension": {
-        "range": {
-          "sheetId": 0,
-          "dimension": "COLUMNS",
-          "startIndex": 2,
-          "endIndex": 3
-        }
-      }
-    },
-    {
-      "moveDimension": {
-        "source": {
-          "sheetId": 0,
-          "dimension": "ROWS",
-          "startIndex": 10,
-          "endIndex": 15
-        },
-        "destinationIndex": 2
-      }
-    }
-  ]
-}
-```
-
-This is the same schema documented in `discovery.json` and used throughout the LLM agent guide.
-
-### Implementation
-
-```python
-async def batch_update_command(
-    url_or_folder: str,
-    requests_file: Path,
-) -> BatchUpdateResult:
-    """Execute batchUpdate requests directly."""
-
-    # Load requests from JSON file
-    with open(requests_file) as f:
-        payload = json.load(f)
-
-    requests = payload.get("requests", [])
-    if not requests:
-        return BatchUpdateResult(success=True, message="No requests to execute")
-
-    # Resolve spreadsheet ID
-    spreadsheet_id = resolve_spreadsheet_id(url_or_folder)
-
-    # Execute via API
-    response = await transport.batch_update(spreadsheet_id, requests)
-
-    return BatchUpdateResult(
-        success=True,
-        message=f"Executed {len(requests)} requests. Run 'extrasheet pull' to refresh.",
-        response=response,
-    )
-```
-
-### When to Use batchUpdate
-
-Use `batchUpdate` for any operation that changes grid dimensions or structure:
-
-| Operation | Example |
-|-----------|---------|
-| Insert rows/columns | `insertDimension` |
-| Delete rows/columns | `deleteDimension` |
-| Move rows/columns | `moveDimension` |
-| Append rows/columns | `appendDimension` |
-| Sort data | `sortRange` |
-| Any other structural change | As needed |
-
-### Convention: Re-pull After batchUpdate
-
-After running `batchUpdate`, always re-pull before making further declarative edits:
-
-```bash
-extrasheet batchUpdate <url> requests.json
-extrasheet pull <url>  # Refresh local state
-```
-
-This is a convention, not enforced by tooling. The reason: after structural changes, cell coordinates shift, so the local files no longer match the remote state.
-
----
-
-## Supported Operations by Workflow
-
-### Declarative Workflow (pull-diff-push)
-
-All content and formatting operations are supported declaratively:
-
-| Category | Operations | Notes |
-|----------|-----------|-------|
-| Cell values | `updateCells` | Diff detects value changes in data.tsv |
-| Formulas | `updateCells` + `autoFill` | Diff detects formula.json changes |
-| Cell formatting | `repeatCell`, `updateBorders` | Diff detects format.json changes |
-| Conditional formatting | `add/update/deleteConditionalFormatRule` | Full support |
-| Merges | `mergeCells`, `unmergeCells` | Diff detects merge changes |
-| Notes | `updateCells` with note field | Diff detects note changes |
-| Data validation | `setDataValidation` | Diff detects validation changes |
-| Basic filter | `setBasicFilter`, `clearBasicFilter` | Full support |
-| Filter views | `add/update/deleteFilterView` | Full support |
-| Banded ranges | `add/update/deleteBanding` | Full support |
-| Named ranges | `add/update/deleteNamedRange` | Full support |
-| Charts | `addChart`, `updateChartSpec`, `deleteEmbeddedObject` | Full support |
-| Tables | `add/update/deleteTable` | Full support |
-| Slicers | `addSlicer`, `updateSlicerSpec` | Full support |
-| Protected ranges | `add/update/deleteProtectedRange` | Full support |
-| Sheet properties | `updateSheetProperties` | Title, frozen, hidden, tab color |
-| Spreadsheet properties | `updateSpreadsheetProperties` | Title, locale, timezone |
-| Dimension properties | `updateDimensionProperties` | Row/column size, hidden |
-| Dimension groups | `add/update/deleteDimensionGroup` | Grouping support |
-| Developer metadata | `create/update/deleteDeveloperMetadata` | Full support |
-| Add new sheet | `addSheet` | Add entry to spreadsheet.json |
-| Delete sheet | `deleteSheet` | Remove entry from spreadsheet.json |
-
-### Imperative Workflow (exec command)
-
-Structural operations require explicit imperative commands:
-
-| Category | Operations | Notes |
-|----------|-----------|-------|
-| Insert rows/columns | `insertDimension` | Explicit command, requires re-pull |
-| Delete rows/columns | `deleteDimension` | Explicit command, requires re-pull |
-| Move rows/columns | `moveDimension` | Explicit command, requires re-pull |
-| Insert cells | `insertRange` | Explicit command, requires re-pull |
-| Delete cells | `deleteRange` | Explicit command, requires re-pull |
-| Append rows/columns | `appendDimension` | Explicit command, requires re-pull |
-| Sort data | `sortRange` | Explicit command, requires re-pull |
-
-### Not Supported
-
-| Category | Reason |
-|----------|--------|
-| Copy/paste operations | Use declarative: edit destination cells directly |
-| Find/replace | Agent can edit files directly |
-| Auto-resize dimensions | Not needed for most use cases |
-| Duplicate sheet | Agent can create new sheet and copy content |
-| Duplicate filter view | Agent can create new filter view |
-| Data sources | Requires external BigQuery/Looker connections |
-| Delete duplicates | Agent can identify and remove in data.tsv |
-| Trim whitespace | Agent can edit values directly |
-| Randomize range | Agent can reorder in data.tsv if needed |
-| Text to columns | Agent can parse and write values |
-
----
-
-## Error Handling
-
-### Validation Errors
-
-```python
-class DiffValidationError(Exception):
-    """Base class for diff validation errors."""
-    pass
-
-class InconsistentStateError(DiffValidationError):
-    """Pristine and current state are inconsistent."""
-    pass
-
-class UnsupportedChangeError(DiffValidationError):
-    """Change type is not supported."""
-    pass
-
-class MissingPristineError(DiffValidationError):
-    """Pristine copy not found - need to re-pull."""
-    pass
-```
-
-### API Errors
-
-When push fails, we should provide helpful context:
-
-```python
-async def push(folder: Path) -> PushResult:
-    """Apply changes to Google Sheets."""
-    try:
-        diff_result = await diff(folder)
-        requests = generate_requests(diff_result)
-
-        if not requests:
-            return PushResult(success=True, changes=0, message="No changes to apply")
-
-        # Log structural operations for visibility
-        structural_ops = [r for r in requests if is_structural(r)]
-        if structural_ops:
-            log.info(f"Structural operations will run last: {len(structural_ops)}")
-
-        response = await transport.batch_update(spreadsheet_id, requests)
-        return PushResult(
-            success=True,
-            changes=len(requests),
-            message=f"Applied {len(requests)} changes",
-        )
-
-    except DiffValidationError as e:
-        return PushResult(
-            success=False,
-            error="validation_error",
-            message=str(e),
-        )
-
-    except APIError as e:
-        # Parse API error for helpful message
-        return PushResult(
-            success=False,
-            error="api_error",
-            message=f"Google Sheets API error: {e.message}",
-            details=e.details,
-        )
-```
-
----
-
-## Testing Strategy
-
-### Unit Tests
-
-1. **Diff detection tests** - Verify correct change detection for each file type
-2. **Request generation tests** - Verify correct batchUpdate JSON structure
-3. **Structural operation detection** - Verify correct ordering of structural operations
-4. **AutoFill generation** - Verify formula ranges generate updateCells + autoFill
-5. **Edge cases** - Empty sheets, large sheets, special characters
-
-### Integration Tests
-
-1. **Golden file tests** - Use saved API responses to verify round-trip
-2. **End-to-end tests** - Pull, modify, diff, verify requests
-
-### Test Data
-
-Create golden files with:
-- Simple sheet with values only
-- Sheet with formulas
-- Sheet with formatting
-- Sheet with all features
-- Large sheet (performance testing)
-
----
-
-## Implementation Plan
-
-### Core Infrastructure
-
-1. **DiffResult data structures**
-   - `SpreadsheetChange` - spreadsheet-level property changes
-   - `SheetChange` - sheet-level changes (add, delete, modify properties)
-   - `CellChange` - individual cell changes (value, formula)
-   - `FormulaRangeChange` - formula range changes (for autoFill)
-   - `FormatChange` - formatting changes
-   - `FeatureChange` - feature changes (charts, filters, etc.)
-
-2. **Pristine extraction**
-   - Extract `.pristine/spreadsheet.zip`
-   - Parse all file types
-   - Build comparison structures
-
-3. **Grid dimension validation**
-   - Verify row/column counts match between pristine and current
-   - Raise `GridDimensionChangedError` if dimensions differ
-
-### Declarative Workflow: Diff
-
-4. **data.tsv diffing**
-   - Validate grid dimensions match
-   - Cell-by-cell comparison within fixed grid
-   - Generate `CellChange` for each modified cell
-
-5. **formula.json diffing**
-   - Range-level comparison
-   - Detect new/modified/deleted ranges
-   - Track first cell + range for autoFill generation
-
-6. **format.json diffing**
-   - `formatRules` comparison
-   - `conditionalFormats` comparison
-   - `merges` comparison
-   - `notes` and `textFormatRuns` comparison
-
-7. **feature.json diffing**
-   - Charts, tables, filters, slicers
-   - Data validation groups
-   - Banded ranges
-
-8. **Other file diffing**
-   - dimension.json (row/column sizes, hidden, groups)
-   - spreadsheet.json (sheet properties, named ranges)
-   - theme.json (default format, theme colors)
-
-### Declarative Workflow: Request Generation
-
-9. **Cell request generation**
-   - `updateCells` for value/formula changes
-   - `autoFill` for formula ranges
-   - Batch by row for efficiency
-
-10. **Format request generation**
-    - `repeatCell` for range formatting
-    - `updateBorders` for borders
-    - `add/update/deleteConditionalFormatRule`
-    - `mergeCells` / `unmergeCells`
-
-11. **Feature request generation**
-    - `addChart`, `updateChartSpec`, `deleteEmbeddedObject`
-    - `addTable`, `updateTable`, `deleteTable`
-    - `add/update/deleteFilterView`
-    - `setBasicFilter`, `clearBasicFilter`
-    - `setDataValidation`
-    - `add/update/deleteBanding`
-    - `addSlicer`, `updateSlicerSpec`
-    - `add/update/deleteProtectedRange`
-
-### Imperative Workflow: batchUpdate Command
-
-12. **batchUpdate command**
-    - Load requests from JSON file
-    - Validate JSON structure
-    - Execute via Google Sheets API
-    - Return response
-
-### CLI Commands
-
-13. **Declarative commands**
-    - `extrasheet diff <folder>` - output batchUpdate JSON
-    - `extrasheet push <folder>` - apply declarative changes
-
-14. **Imperative command**
-    - `extrasheet batchUpdate <url> <requests.json>` - execute any batchUpdate requests
-
-### Testing
-
-15. **Golden file tests**
-    - Create test spreadsheets with all features
-    - Pull, modify, diff, verify requests
-    - Test grid dimension validation errors
-
-16. **batchUpdate tests**
-    - Test request loading from JSON
-    - Test API execution
+`push` does not update `.pristine`. Re-pull after every successful push.
+
+## Files Read By The Diff Engine
+
+Root level:
+
+- `spreadsheet.json`
+- `theme.json` read from disk but currently ignored for diff/push
+- `named_ranges.json`
+
+Per sheet:
+
+- `data.tsv`
+- `formula.json`
+- `format.json`
+- `dimension.json`
+- `feature.json` for backward compatibility only
+- `charts.json`
+- `pivot-tables.json`
+- `tables.json`
+- `filters.json`
+- `banded-ranges.json`
+- `data-validation.json`
+- `slicers.json`
+- `data-source-tables.json`
+
+Handled outside the main diff engine:
+
+- `comments.json`
+
+Not currently read for push:
+
+- `developer_metadata.json`
+- `data_sources.json`
+- `protection.json`
+
+## Spreadsheet-Level Support
+
+Supported from `spreadsheet.json`:
+
+- `properties.title`
+
+Pulled but informational only:
+
+- `properties.locale`
+- `properties.autoRecalc`
+- `properties.timeZone`
+- `_truncationWarning`
+- `sheets[].preview`
+- `sheets[].truncation`
+
+## Sheet-Level Support
+
+Supported from each entry in `spreadsheet.json`:
+
+- `title`
+- `hidden`
+- `rightToLeft`
+- `tabColor`
+- `tabColorStyle`
+- `gridProperties.frozenRowCount`
+- `gridProperties.frozenColumnCount`
+
+Also supported structurally:
+
+- Add a new sheet by adding an entry/folder
+- Delete a sheet by removing an entry/folder
+- Insert/delete rows by editing `data.tsv`
+- Insert/delete columns by editing `data.tsv`
+
+## Per-File Behavior
+
+### `data.tsv`
+
+Supported:
+
+- Cell value add/update/delete
+- Row insertion/deletion inferred from grid shape changes
+- Column insertion/deletion inferred from grid shape changes
+
+Notes:
+
+- Formula cells should stay blank in `data.tsv`; formulas belong in
+  `formula.json`.
+- Validation may block structural edits that would silently conflict with
+  formula edits.
+
+### `formula.json`
+
+Supported:
+
+- Add/update/delete formulas
+- Compressed range formulas
+
+### `format.json`
+
+Supported:
+
+- `formatRules`
+- `conditionalFormats`
+- `merges`
+- `notes`
+- `textFormatRuns`
+
+Notes:
+
+- Existing conditional formats keep their `ruleIndex`.
+- New conditional format rules may omit `ruleIndex`; diff auto-assigns one after
+  the highest existing index.
+
+### `dimension.json`
+
+Supported:
+
+- `rowMetadata[].pixelSize`
+- `rowMetadata[].hidden`
+- `columnMetadata[].pixelSize`
+- `columnMetadata[].hidden`
+
+Pulled but ignored today:
+
+- `rowGroups`
+- `columnGroups`
+- `developerMetadata`
+- dimension-level `developerMetadata` entries inside row/column metadata
+
+### Feature Files
+
+Supported:
+
+- `charts.json`
+- `pivot-tables.json`
+- `tables.json`
+- `filters.json`
+- `banded-ranges.json`
+- `data-validation.json`
+- `slicers.json`
+- `named_ranges.json`
+
+Partially supported:
+
+- `data-source-tables.json`
+  - refresh/modify-style operations are supported
+  - creating or deleting data source tables is not
+
+### `comments.json`
+
+Supported:
+
+- Add a reply by appending a reply object without an `id`
+- Resolve a comment by setting `"resolved": true`
+
+Not supported:
+
+- Creating new top-level comments
+- Moving comments to a different cell
+- Editing historical author/time fields
+
+## Request Ordering
+
+The generated Sheets API requests are ordered like this:
+
+1. Spreadsheet property changes
+2. `addSheet`
+3. Row/column grid changes
+4. Sheet property changes
+5. Cell/formula/format/dimension/feature changes
+6. Named range changes
+7. `deleteSheet`
+
+Comment replies/resolution are executed after the Sheets API requests because
+they go through Drive comments APIs, not `batchUpdate`.
+
+## When To Use `batchUpdate` Directly
+
+Use `extrasuite sheet batchUpdate` for operations that are not represented by
+the declarative file model or are not yet wired into diff/push, for example:
+
+- `sortRange`
+- `moveDimension`
+- `findReplace`
+- `autoResizeDimensions`
+- protection edits
+- developer metadata edits
+- spreadsheet locale/timezone/default-theme changes
+
+## Validation Rules
+
+Structural validation runs before push:
+
+- `BLOCK`: structurally unsafe changes combined with formula edits
+- `WARN`: changes likely to break existing formulas; push requires `--force`
+
+Warnings do not stop `diff`; they do stop `push` unless forced.

--- a/extrasheet/docs/gaps.md
+++ b/extrasheet/docs/gaps.md
@@ -1,25 +1,62 @@
-# ExtraSheet: Push Gaps
+# ExtraSheet: Current Gaps
 
-Remaining properties that are extracted and stored on pull but not supported during push.
+This file tracks the parts of the pulled representation that are still read-only
+or only partially supported during diff/push.
 
-## Data Source Tables (data-source-tables.json)
+## Pull-Only Root Files
 
-| Operation | Supported? |
-|-----------|-----------|
-| Refresh | Yes |
-| Add | **No** |
-| Delete | **No** |
+These files are emitted on pull but ignored on push:
 
-Low priority — these are rarely used and typically managed through the Google Sheets UI.
+- `theme.json`
+- `developer_metadata.json`
+- `data_sources.json`
 
-## Resolved Gaps
+## Pull-Only Sheet Files Or Sections
 
-The following gaps have been fixed:
+- `protection.json`
+- `dimension.json.rowGroups`
+- `dimension.json.columnGroups`
+- `dimension.json.developerMetadata`
+- `dimension.json` row/column `developerMetadata`
 
-- **Format properties:** `wrapStrategy`, `padding`, `textDirection`, `textRotation` — added to `_convert_to_cell_format()` and `_get_format_fields()`
-- **Borders:** Uses `updateBorders` request via `_build_update_borders_request()`
-- **Dimension hidden:** `hidden` property diffed and pushed as `hiddenByUser`
-- **Dimension deletion:** Resets to default pixelSize (21px rows, 100px columns)
-- **Format rule deletion:** Clears formatting via `repeatCell` with empty format + `updateBorders` with `NONE` style
-- **tabColor/tabColorStyle:** Diffed and pushed via `updateSheetProperties` with `tabColorStyle`
-- **rightToLeft:** Diffed and pushed via `updateSheetProperties`
+Row/column `pixelSize` and `hidden` are supported. The grouping and metadata
+sections are not.
+
+## Spreadsheet Properties Not Pushed
+
+`spreadsheet.json.properties` currently supports only:
+
+- `title`
+
+These are informational only:
+
+- `locale`
+- `autoRecalc`
+- `timeZone`
+
+## Comments Limits
+
+`comments.json` supports:
+
+- new replies
+- resolving existing comments
+
+It does not support:
+
+- creating new top-level comments
+- relocating comments by cell reference
+
+## Data Source Tables
+
+`data-source-tables.json` is only partially supported:
+
+- Refresh/modify style updates are supported
+- Add/delete is not
+
+## Not Extracted
+
+These still are not represented in the local file model:
+
+- smart chips
+- embedded images as editable artifacts
+- version history

--- a/extrasheet/docs/on-disk-format.md
+++ b/extrasheet/docs/on-disk-format.md
@@ -1,206 +1,155 @@
 # Extrasheet On-Disk Format Specification
 
-Version: 2.3.0
-Last Updated: 2026-01-30
+Version: 2.4.0
+Last Updated: 2026-03-06
 
-## Overview
+This document describes the current on-disk format emitted by
+`extrasuite sheet pull` / `SheetsClient.pull()`.
 
-Extrasheet transforms Google Sheets spreadsheets into a file-based representation. The format separates data, formulas, formatting, and features into distinct files to enable token-efficient loading by LLM agents.
-
-This document describes the current implementation's output format.
+It was cross-checked against the implementation in `transformer.py`,
+`client.py`, `diff.py`, and a live pull of spreadsheet
+`1popsVtwuaYvGK8-ZkLIibesvbfnljjpUiOVWFMBMDkU`.
 
 ## Directory Structure
 
-```
+```text
 <output_dir>/
-└── <spreadsheet_id>/
-    ├── spreadsheet.json           # Spreadsheet metadata, sheet index, and data previews
-    ├── theme.json                 # Default formatting and theme colors (if any)
-    ├── named_ranges.json          # Named ranges (if any exist)
-    ├── developer_metadata.json    # Developer metadata (if any exist)
-    ├── data_sources.json          # External data sources (if any exist)
-    ├── <sheet_folder>/            # One folder per sheet
-    │   ├── data.tsv               # Cell values as tab-separated values
-    │   ├── formula.json           # Formulas (sparse representation)
-    │   ├── format.json            # Cell formatting
-    │   ├── charts.json            # Embedded charts (if any)
-    │   ├── pivot-tables.json      # Pivot tables (if any)
-    │   ├── tables.json            # Structured tables (if any)
-    │   ├── filters.json           # Basic filter + filter views (if any)
-    │   ├── banded-ranges.json     # Alternating row/column colors (if any)
-    │   ├── data-validation.json   # Input validation rules (if any)
-    │   ├── slicers.json           # Interactive filter slicers (rare)
-    │   ├── data-source-tables.json # Data source tables (rare)
-    │   ├── dimension.json         # Row/column sizing and groups
-    │   └── protection.json        # Protected ranges (if any exist)
-    ├── .raw/                      # Raw API responses (saved by default)
-    │   ├── metadata.json          # Metadata API response (no grid data)
-    │   └── data.json              # Data API response (with grid data)
-    └── .pristine/
-        └── spreadsheet.zip        # Pristine copy for diff/push workflow
+  <spreadsheet_id>/
+    spreadsheet.json
+    theme.json                     # optional, informational
+    named_ranges.json              # optional, editable
+    developer_metadata.json        # optional, informational
+    data_sources.json              # optional, informational
+    <sheet_folder>/
+      data.tsv
+      formula.json
+      format.json                  # optional
+      dimension.json               # optional
+      charts.json                  # optional
+      pivot-tables.json            # optional
+      tables.json                  # optional
+      filters.json                 # optional
+      banded-ranges.json           # optional
+      data-validation.json         # optional
+      slicers.json                 # optional
+      data-source-tables.json      # optional
+      protection.json              # optional, informational
+      comments.json                # optional, replies/resolve only
+    .raw/
+      metadata.json                # omitted when pull uses --no-raw
+      data.json
+    .pristine/
+      spreadsheet.zip
 ```
-
-### Raw API Responses
-
-The `.raw/` folder contains the raw Google Sheets API responses, saved by default:
-
-- **metadata.json** - First API call response (spreadsheet metadata without grid data)
-- **data.json** - Second API call response (with grid data, limited by `--max-rows`)
-
-These files are useful for:
-- Debugging transformation issues
-- Creating golden files for testing
-- Understanding what data the API returned
-
-Use `--no-raw` to skip saving these files.
-
-### Pristine Copy
-
-The `.pristine/spreadsheet.zip` file contains an exact copy of all files as they were when pulled. This enables the diff/push workflow:
-
-1. **pull** - Creates files and stores pristine copy in `.pristine/spreadsheet.zip`
-2. **edit** - Agent modifies files in place
-3. **diff** - Compares current files against pristine copy to generate `batchUpdate` JSON
-4. **push** - Same as diff, but applies changes to Google Sheets API
-
-The zip contains all files with paths relative to the spreadsheet folder (e.g., `spreadsheet.json`, `Sheet1/data.tsv`). The `.raw/` folder is excluded from the pristine copy since it's not part of the canonical representation.
-
-### Sheet Folder Naming
-
-Sheet folders are named using the sanitized sheet title:
-- Invalid filesystem characters (`/`, `\`, `:`, `*`, `?`, `"`, `<`, `>`, `|`) are replaced with `_`
-- Leading/trailing whitespace and dots are trimmed
-- Multiple consecutive underscores are collapsed to one
-- If duplicate folder names exist after sanitization, `_<sheetId>` is appended
-
-Example: Sheet "Other Locations / Virtual" becomes folder `Other Locations _ Virtual`
 
 ### File Creation Rules
 
-Files are only created when they contain meaningful data:
-- `theme.json` - Only if spreadsheet has defaultFormat or spreadsheetTheme
-- `formula.json` - Only if sheet has formulas
-- `format.json` - Only if sheet has non-default formatting, conditional formats, merges, text runs, or notes
-- `charts.json` - Only if sheet has embedded charts
-- `pivot-tables.json` - Only if sheet has pivot tables
-- `tables.json` - Only if sheet has structured tables
-- `filters.json` - Only if sheet has basic filter or filter views
-- `banded-ranges.json` - Only if sheet has alternating row/column colors
-- `data-validation.json` - Only if sheet has input validation rules
-- `slicers.json` - Only if sheet has interactive filter slicers
-- `data-source-tables.json` - Only if sheet has data source tables
-- `dimension.json` - Only if sheet has non-default row/column sizes, groups, or dimension metadata
-- `protection.json` - Only if sheet has protected ranges
-- `named_ranges.json` - Only if spreadsheet has named ranges
-- `developer_metadata.json` - Only if spreadsheet has developer metadata
-- `data_sources.json` - Only if spreadsheet has external data sources
+- `spreadsheet.json` is always written.
+- `data.tsv` and `formula.json` are always written for empty GRID sheets as stub
+  files (`""` and `{}` respectively).
+- Non-empty optional files are only written when the source spreadsheet has
+  relevant content.
+- `comments.json` is written per sheet only when Drive comments for that sheet
+  exist.
+- `.raw/*` is skipped when `--no-raw` / `save_raw=False` is used.
 
----
+## Root-Level Files
 
-## Spreadsheet-Level Files
+### `spreadsheet.json`
 
-### spreadsheet.json
+Entry point for understanding the spreadsheet.
 
-Contains spreadsheet metadata, an index of all sheets, and data previews for quick understanding.
-
-**Design for progressive disclosure:** This file is optimized for LLM agents to understand the spreadsheet structure at a glance. Theme and formatting details are stored separately in `theme.json` to keep this file focused on content.
+Example:
 
 ```json
 {
-  "spreadsheetId": "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms",
-  "spreadsheetUrl": "https://docs.google.com/spreadsheets/d/.../edit",
+  "spreadsheetId": "1popsVtwuaYvGK8-ZkLIibesvbfnljjpUiOVWFMBMDkU",
+  "spreadsheetUrl": "https://docs.google.com/spreadsheets/d/1popsVtwuaYvGK8-ZkLIibesvbfnljjpUiOVWFMBMDkU/edit",
   "properties": {
-    "title": "My Spreadsheet",
-    "locale": "en_US",
+    "title": "R41 Interview COGS Model",
+    "locale": "en_GB",
     "autoRecalc": "ON_CHANGE",
-    "timeZone": "America/New_York"
+    "timeZone": "Asia/Calcutta"
   },
   "sheets": [
     {
-      "sheetId": 0,
-      "title": "Sheet1",
+      "sheetId": 177409360,
+      "title": "Inputs",
       "index": 0,
       "sheetType": "GRID",
-      "folder": "Sheet1",
+      "folder": "Inputs",
       "gridProperties": {
-        "rowCount": 1000,
-        "columnCount": 26,
-        "frozenRowCount": 1,
-        "frozenColumnCount": 0
+        "rowCount": 100,
+        "columnCount": 10
       },
-      "hidden": false,
-      "tabColorStyle": { "rgbColor": { "red": 1.0, "green": 0, "blue": 0 } },
       "preview": {
-        "firstRows": [
-          ["Name", "Age", "City", "Sales"],
-          ["Alice", "30", "NYC", "1000"],
-          ["Bob", "25", "LA", "1500"],
-          ["Carol", "35", "Chicago", "2000"],
-          ["Dave", "28", "Boston", "1200"]
-        ],
-        "lastRows": [
-          ["Tom", "40", "Miami", "800"],
-          ["Sue", "32", "Denver", "950"],
-          ["Joe", "45", "Seattle", "1100"]
-        ]
+        "firstRows": [["RECRUIT41 INTERVIEW COGS MODEL - INPUTS"]],
+        "lastRows": [["Chunk Duration", "10", "minutes", ""]]
+      }
+    },
+    {
+      "sheetId": 657127928,
+      "title": "Documentation",
+      "index": 3,
+      "sheetType": "GRID",
+      "folder": "Documentation",
+      "gridProperties": {
+        "rowCount": 150,
+        "columnCount": 5
+      },
+      "truncation": {
+        "totalRows": 150,
+        "fetchedRows": 100,
+        "truncated": true
       }
     }
-  ]
+  ],
+  "_truncationWarning": "Some sheets have partial data. Check each sheet's 'truncation' field for details."
 }
 ```
 
-**Key Fields:**
+Key points:
 
-| Field | Description |
-|-------|-------------|
-| `spreadsheetId` | Unique identifier for the spreadsheet |
-| `spreadsheetUrl` | URL to open the spreadsheet in browser |
-| `properties.title` | Spreadsheet title |
-| `properties.locale` | Locale for formatting (e.g., `en_US`) |
-| `properties.timeZone` | Time zone for date calculations |
-| `sheets[].sheetId` | Unique numeric ID for each sheet (used in API calls) |
-| `sheets[].title` | Display title of the sheet |
-| `sheets[].folder` | Sanitized folder name on disk |
-| `sheets[].sheetType` | `GRID`, `OBJECT`, or `DATA_SOURCE` |
-| `sheets[].gridProperties` | Row/column counts and frozen dimensions |
-| `sheets[].hidden` | `true` if sheet is hidden (omitted if visible) |
-| `sheets[].preview.firstRows` | First 5 rows of data (for quick understanding) |
-| `sheets[].preview.lastRows` | Last 3 rows of data (non-overlapping with firstRows) |
+- `properties` only keeps `title`, `locale`, `autoRecalc`, and `timeZone`.
+- `preview` exists only for GRID sheets.
+- `hidden`, `rightToLeft`, `tabColor`, and `tabColorStyle` appear only when set.
+- `truncation` appears on individual sheets when row limiting cut data short.
+- `_truncationWarning` appears at the top level when any sheet was truncated.
 
-### theme.json
+Push support from this file:
 
-Contains default cell formatting and spreadsheet theme colors. This file is separated from `spreadsheet.json` to keep the main metadata file focused on content structure.
+- spreadsheet `properties.title`
+- sheet `title`
+- sheet `hidden`
+- sheet `rightToLeft`
+- sheet `tabColor` / `tabColorStyle`
+- sheet `gridProperties.frozenRowCount`
+- sheet `gridProperties.frozenColumnCount`
+- new/delete sheet detection via the `sheets` list and sheet folders
 
-```json
-{
-  "defaultFormat": {
-    "backgroundColor": { "red": 1, "green": 1, "blue": 1 },
-    "padding": { "top": 2, "right": 3, "bottom": 2, "left": 3 },
-    "verticalAlignment": "BOTTOM",
-    "wrapStrategy": "OVERFLOW_CELL",
-    "textFormat": {
-      "fontFamily": "arial,sans,sans-serif",
-      "fontSize": 10,
-      "bold": false,
-      "italic": false
-    }
-  },
-  "spreadsheetTheme": {
-    "primaryFontFamily": "Arial",
-    "themeColors": [
-      { "colorType": "TEXT", "color": { "rgbColor": {} } },
-      { "colorType": "BACKGROUND", "color": { "rgbColor": { "red": 1, "green": 1, "blue": 1 } } },
-      { "colorType": "ACCENT1", "color": { "rgbColor": { "red": 0.26, "green": 0.52, "blue": 0.96 } } }
-    ]
-  }
-}
-```
+Informational only today:
 
-**When to use:** Only read this file if you need to understand or modify the spreadsheet's default formatting or theme colors. Most editing tasks don't require this file.
+- `properties.locale`
+- `properties.autoRecalc`
+- `properties.timeZone`
+- `preview`
+- `truncation`
+- `_truncationWarning`
 
-### named_ranges.json
+### `theme.json`
 
-Contains all named ranges defined in the spreadsheet.
+Spreadsheet default format and theme metadata. Written when the spreadsheet has
+`defaultFormat` or `spreadsheetTheme`.
+
+This file is currently informational only. Diff/push does not apply edits to it.
+
+Note: editable files use hex colors for concrete color values, but pull-only
+metadata files may still contain API-style wrappers such as
+`{"rgbColor": "#FFFFFF"}` or empty objects.
+
+### `named_ranges.json`
+
+Spreadsheet-level named ranges in A1 notation.
 
 ```json
 {
@@ -208,153 +157,112 @@ Contains all named ranges defined in the spreadsheet.
     {
       "namedRangeId": "abc123",
       "name": "SalesData",
-      "range": "Sheet1!A1:E100"
+      "range": "Sheet1!A1:E100",
+      "sheetId": 0
     }
   ]
 }
 ```
 
-**Note:** Ranges use A1 notation with sheet name prefix.
+This file is diffed and pushed.
 
-### developer_metadata.json
+### `developer_metadata.json`
 
-Contains spreadsheet-level developer metadata.
+Spreadsheet-level developer metadata.
 
-```json
-{
-  "developerMetadata": [
-    {
-      "metadataId": 12345,
-      "metadataKey": "app-version",
-      "metadataValue": "1.0.0",
-      "location": {
-        "locationType": "SPREADSHEET"
-      },
-      "visibility": "DOCUMENT"
-    }
-  ]
-}
-```
+Written on pull when present. Informational only today.
 
-### data_sources.json
+### `data_sources.json`
 
-Contains external data source connections (BigQuery, Looker).
+Spreadsheet-level external data source metadata and refresh schedules.
 
-```json
-{
-  "dataSources": [
-    {
-      "dataSourceId": "datasource_abc",
-      "spec": {
-        "bigQuery": {
-          "projectId": "my-project",
-          "querySpec": {
-            "rawQuery": "SELECT * FROM dataset.table"
-          }
-        }
-      }
-    }
-  ],
-  "refreshSchedules": [
-    {
-      "enabled": true,
-      "refreshScope": "ALL_DATA_SOURCES",
-      "dailySchedule": {
-        "startTime": { "hours": 6, "minutes": 0 }
-      }
-    }
-  ]
-}
-```
+Written on pull when present. Informational only today.
 
----
+### `.raw/metadata.json` and `.raw/data.json`
+
+Raw API responses saved by default for debugging and golden-file creation.
+
+These files are not part of the canonical editable representation and are not
+included in `.pristine/spreadsheet.zip`.
+
+### `.pristine/spreadsheet.zip`
+
+Canonical snapshot of the pulled representation used by `diff` and `push`.
+
+Re-pull after every successful push. The zip is not updated in place.
+
+## Sheet Folder Naming
+
+Sheet folders are based on sanitized sheet titles:
+
+- invalid filesystem characters become `_`
+- leading/trailing whitespace and dots are trimmed
+- repeated underscores collapse
+- if sanitization would collide, `_<sheetId>` is appended
+
+Example:
+
+- `Other Locations / Virtual` -> `Other Locations _ Virtual`
 
 ## Sheet-Level Files
 
-### data.tsv
+### `data.tsv`
 
-Tab-separated values containing cell data. Formulas display their computed result, not the formula text.
+Tab-separated cell values.
 
-**Format:**
-- Each row contains cell values separated by tabs
-- Trailing empty columns and rows are trimmed
-- Row and column indices are zero-based (first row is row 0, first column is column 0)
+Rules:
 
-**Escaping:**
-- Tab characters: `\t`
-- Newline characters: `\n`
-- Carriage return: `\r`
-- Backslash: `\\`
+- Each line is one spreadsheet row.
+- Each tab-separated field is one spreadsheet cell.
+- Trailing empty rows and columns are trimmed.
+- Formulas appear here as computed values, not formula text.
+- Values are derived from `effectiveValue`.
 
-**Example:**
-```
-Name	Sales	Region	Total
-Alice	1000	North	1500
-Bob	500	South	1200
-```
+Escaping:
 
-**Value Representation:**
+- tab -> `\t`
+- newline -> `\n`
+- carriage return -> `\r`
+- backslash -> `\\`
 
-| Type | Representation |
-|------|----------------|
-| String | Raw text |
-| Number | Raw numeric value (e.g., `1234.56` not `$1,234.56`) |
-| Boolean | `TRUE` or `FALSE` |
-| Date/Time | Serial number (days since 1899-12-30) |
-| Error | Error string (e.g., `#REF!`, `#N/A`, `#DIV/0!`) |
-| Empty | Empty string |
+Typical value representation:
 
-**Source:** Values are extracted from `CellData.effectiveValue` to preserve type information for round-trip safety. This means numbers appear as raw values without formatting (currency symbols, percentage signs, etc.). Formatting information is available in `format.json`.
+| Sheet value | TSV value |
+|-------------|-----------|
+| text | raw text |
+| number | raw number like `1234.56` |
+| boolean | `TRUE` / `FALSE` |
+| date/time | serial number |
+| error | API error message text |
+| empty | empty string |
 
-### formula.json
+There are no explicit row or column numbers inside the file. Line number and
+field position imply the grid position.
 
-Formulas are stored as a flat dictionary where keys are either single cell references or ranges, and values are the formula strings. When multiple contiguous cells share the same formula pattern (with relative references), they are compressed into a single range entry.
+### `formula.json`
+
+Sparse map of formulas by A1 cell or A1 range.
 
 ```json
 {
-  "B2:K2": "='Operating Model'!B37",
-  "B3:K3": "=B2*operating_expense_ratio",
-  "B4:K4": "=B2-B3",
-  "A1": "=NOW()",
-  "Z1": "=UNIQUE(Sheet2!A:A)"
+  "B4": "=Inputs!C44/Inputs!B35",
+  "B5:D5": "=B4*0.3"
 }
 ```
 
-**Format:**
+Rules:
 
-- **Keys**: Cell references (`"A1"`) or ranges (`"B2:K2"`)
-- **Values**: The formula string as entered in the first cell
+- keys are cell references or ranges
+- values are the formula from the first cell in the range
+- relative references auto-fill across compressed ranges
+- computed results still live in `data.tsv`
 
-**Range Compression:**
+Empty GRID sheets get `{}` so the sheet folder still exposes a writable formula
+surface.
 
-When contiguous cells share the same relative reference pattern, they are compressed into a single entry:
+### `format.json`
 
-```json
-{
-  "C2:C100": "=A2+B2"
-}
-```
-
-This means:
-- C2: `=A2+B2`
-- C3: `=A3+B3` (row references increment)
-- C4: `=A4+B4`
-- ... and so on to C100
-
-The formula auto-fills across the range using standard Excel/Google Sheets behavior: relative references increment, absolute references (like `$A$1`) stay fixed.
-
-**Additional Sections (if present):**
-
-| Section | Description |
-|---------|-------------|
-| `arrayFormulas` | Array formulas with their output range (rare) |
-| `dataSourceFormulas` | Formulas connected to external data sources (rare) |
-
-**Note:** The computed values appear in `data.tsv`. The `formula.json` file only contains cells that have formulas.
-
-### format.json
-
-Cell formatting is stored with range-based compression. Cells with identical formatting are grouped into rectangular ranges.
+Formatting for cells, merges, notes, and rich text.
 
 ```json
 {
@@ -362,20 +270,10 @@ Cell formatting is stored with range-based compression. Cells with identical for
     {
       "range": "A1:J1",
       "format": {
-        "horizontalAlignment": "CENTER",
-        "textFormat": { "bold": true }
-      }
-    },
-    {
-      "range": "F2:F50",
-      "format": {
-        "numberFormat": { "type": "NUMBER", "pattern": "$#,##0" }
-      }
-    },
-    {
-      "range": "A2:A23",
-      "format": {
-        "backgroundColor": "#FFD9D9"
+        "backgroundColor": "#CCCCCC",
+        "textFormat": {
+          "bold": true
+        }
       }
     }
   ],
@@ -386,7 +284,7 @@ Cell formatting is stored with range-based compression. Cells with identical for
       "booleanRule": {
         "condition": {
           "type": "NUMBER_GREATER",
-          "values": [{ "userEnteredValue": "1000" }]
+          "values": [{"userEnteredValue": "1000"}]
         },
         "format": {
           "backgroundColor": "#CCFFCC"
@@ -400,184 +298,101 @@ Cell formatting is stored with range-based compression. Cells with identical for
     }
   ],
   "textFormatRuns": {
-    "E22": [
-      { "format": {} },
-      {
-        "startIndex": 23,
-        "format": {
-          "foregroundColor": "#1254CC",
-          "underline": true,
-          "link": { "uri": "https://example.com" }
-        }
-      }
+    "A1": [
+      {"format": {}},
+      {"startIndex": 5, "format": {"bold": true}}
     ]
   },
   "notes": {
-    "A1": "This is a cell note"
+    "A1": "Cell note text"
   }
 }
 ```
 
-**Format Compression:**
+Key points:
 
-The `formatRules` array contains range-based formatting rules:
+- concrete editable colors are normalized to hex strings
+- `notes` are cell notes, not Drive comments
+- `textFormatRuns` is keyed by cell A1 notation
+- existing conditional format rules keep their `ruleIndex`
+- new conditional format rules may omit `ruleIndex`; diff assigns one
 
-1. **Range-based rules**: Cells with identical formatting are grouped into the largest possible rectangular ranges
-2. **Cascade model**: Rules are applied in order; later rules override earlier ones for overlapping cells
-3. **Delta encoding**: When a dominant format exists, rules for other cells only contain properties that differ
-4. **Format optimization**: Deprecated fields are removed (e.g., `backgroundColor` when `backgroundColorStyle` exists)
+### `dimension.json`
 
-**Format Rule Fields:**
-
-| Field | Description |
-|-------|-------------|
-| `range` | A1 notation for the range this rule applies to |
-| `format` | CellFormat object with formatting properties |
-
-**Conditional Format Fields:**
-
-| Field | Description |
-|-------|-------------|
-| `ruleIndex` | Zero-based index for updating/deleting rules |
-| `ranges` | Array of A1-notation ranges the rule applies to |
-| `booleanRule` | Condition + format for boolean rules |
-| `gradientRule` | Min/mid/max colors for gradient rules |
-
-### Feature Files (Split Format)
-
-Advanced spreadsheet features are stored in separate JSON files per feature type. This split format provides better organization and allows agents to read only the features they need.
-
-**Note:** The diff/push workflow supports both the new split format and the legacy `feature.json` for backward compatibility.
-
-#### charts.json
-
-Embedded charts with position and specification.
+Row/column size and visibility metadata, plus some informational sections.
 
 ```json
 {
-  "charts": [
-    {
-      "chartId": 123456,
-      "position": {
-        "overlayPosition": {
-          "anchorCell": "F1",
-          "widthPixels": 400,
-          "heightPixels": 300
-        }
-      },
-      "spec": {
-        "title": "Sales by Region",
-        "basicChart": {
-          "chartType": "BAR",
-          "axis": [...],
-          "domains": [{"domain": {"sourceRange": {"sources": [{"range": "A2:A10"}]}}}],
-          "series": [{"series": {"sourceRange": {"sources": [{"range": "B2:B10"}]}}}]
-        }
-      }
-    }
+  "rowMetadata": [
+    {"row": 11, "pixelSize": 50, "hidden": true}
+  ],
+  "columnMetadata": [
+    {"column": "A", "pixelSize": 150}
+  ],
+  "rowGroups": [
+    {"range": "6:10", "depth": 1, "collapsed": false}
   ]
 }
 ```
 
-#### pivot-tables.json
+Writable today:
 
-Pivot tables with anchor cell and configuration.
+- `rowMetadata[].pixelSize`
+- `rowMetadata[].hidden`
+- `columnMetadata[].pixelSize`
+- `columnMetadata[].hidden`
 
-```json
-{
-  "pivotTables": [
-    {
-      "anchorCell": "G1",
-      "source": "A1:E100",
-      "rows": [...],
-      "columns": [...],
-      "values": [...]
-    }
-  ]
-}
-```
+Informational only today:
 
-**Pivot Table Editing:** You can add, modify, or delete pivot tables by editing this file. The anchor cell (A1 notation) identifies each pivot table.
+- `rowGroups`
+- `columnGroups`
+- `developerMetadata`
+- row/column `developerMetadata`
 
-#### tables.json
+Conventions:
 
-Structured tables with column definitions.
+- row numbers are 1-based
+- columns use letters
 
-```json
-{
-  "tables": [
-    {
-      "tableId": "1778223018",
-      "name": "Table1",
-      "range": "A1:J47",
-      "columnProperties": [
-        { "column": "A", "columnName": "Category" },
-        { "column": "B", "columnName": "Resource Type" }
-      ]
-    }
-  ]
-}
-```
+### `charts.json`
 
-#### filters.json
+Embedded charts. Diff/push supports add/modify/delete.
 
-Basic filter and filter views.
+### `pivot-tables.json`
 
-```json
-{
-  "basicFilter": {
-    "range": "A1:E100",
-    "sortSpecs": [...],
-    "filterSpecs": [{"column": "C", "filterCriteria": {...}}]
-  },
-  "filterViews": [
-    {
-      "filterViewId": 789,
-      "title": "Top Performers",
-      "range": "A1:E100",
-      "filterSpecs": [{"column": "B", "filterCriteria": {...}}]
-    }
-  ]
-}
-```
+Pivot tables keyed by `anchorCell`. Diff/push supports add/modify/delete.
 
-#### banded-ranges.json
+### `tables.json`
 
-Alternating row/column colors.
+Structured tables. Diff/push supports add/modify/delete.
 
-```json
-{
-  "bandedRanges": [
-    {
-      "bandedRangeId": 1778223018,
-      "range": "A1:E100",
-      "rowProperties": {
-        "headerColor": "#336699",
-        "firstBandColor": "#FFFFFF",
-        "secondBandColor": "#F2F2F2"
-      }
-    }
-  ]
-}
-```
+### `filters.json`
 
-#### data-validation.json
+Contains:
 
-Input validation rules grouped by rule type.
+- `basicFilter`
+- `filterViews`
+
+Diff/push supports both.
+
+### `banded-ranges.json`
+
+Alternating row/column color definitions. Diff/push supports add/modify/delete.
+
+### `data-validation.json`
+
+Grouped validation rules.
 
 ```json
 {
   "dataValidation": [
     {
       "range": "H2... (49 cells)",
-      "cells": ["H2", "H3", "H4", ...],
+      "cells": ["H2", "H3", "H4"],
       "rule": {
         "condition": {
           "type": "ONE_OF_LIST",
-          "values": [
-            { "userEnteredValue": "Keep" },
-            { "userEnteredValue": "Delete" }
-          ]
+          "values": [{"userEnteredValue": "Keep"}]
         },
         "showCustomUi": true
       }
@@ -586,365 +401,84 @@ Input validation rules grouped by rule type.
 }
 ```
 
-Cells with identical validation rules are grouped together. The `cells` array lists all cells with that rule, and `range` provides a summary.
+Cells with identical rules are grouped together. The `range` field is only a
+human-readable summary; `cells` is the canonical per-cell list.
 
-#### slicers.json (rare)
+### `slicers.json`
 
-Interactive filter slicers.
+Interactive filter slicers. Diff/push supports add/modify/delete.
+
+### `data-source-tables.json`
+
+Tables backed by external data sources.
+
+Current support is partial:
+
+- modify/refresh-style changes are supported
+- creating or deleting data source tables is not
+
+### `protection.json`
+
+Protected ranges and editor metadata.
+
+This file is emitted on pull when present but is informational only today.
+
+### `comments.json`
+
+Drive comments for a single sheet.
 
 ```json
 {
-  "slicers": [
+  "fileId": "spreadsheet_id",
+  "comments": [
     {
-      "slicerId": 456,
-      "position": {
-        "overlayPosition": {
-          "anchorCell": "M1",
-          "widthPixels": 200,
-          "heightPixels": 300
+      "id": "AAABzqZTYuo",
+      "author": "Alice <alice@example.com>",
+      "time": "2024-01-15T10:30:00.000Z",
+      "resolved": false,
+      "content": "Please double-check this formula",
+      "quotedContent": "=SUM(B2:B10)",
+      "replies": [
+        {
+          "id": "AAABzqZTYus",
+          "author": "Bob <bob@example.com>",
+          "time": "2024-01-15T11:00:00.000Z",
+          "content": "Verified"
         }
-      },
-      "spec": {
-        "dataRange": "A1:E100",
-        "title": "Region Filter",
-        "column": "C"
-      }
+      ]
     }
   ]
 }
 ```
 
-#### data-source-tables.json (rare)
+Notes:
 
-Tables connected to external data sources.
-
-```json
-{
-  "dataSourceTables": [
-    {
-      "anchorCell": "M1",
-      "dataSourceId": "datasource_abc",
-      "columns": [...]
-    }
-  ]
-}
-```
-
-**Feature Files Summary:**
-
-| File | Content | Source |
-|------|---------|--------|
-| `charts.json` | Embedded charts | `Sheet.charts[]` |
-| `pivot-tables.json` | Pivot tables | `CellData.pivotTable` |
-| `tables.json` | Structured tables | `Sheet.tables[]` |
-| `filters.json` | Basic filter + filter views | `Sheet.basicFilter`, `Sheet.filterViews[]` |
-| `banded-ranges.json` | Alternating colors | `Sheet.bandedRanges[]` |
-| `data-validation.json` | Input validation | `CellData.dataValidation` |
-| `slicers.json` | Interactive slicers | `Sheet.slicers[]` |
-| `data-source-tables.json` | External data tables | `CellData.dataSourceTable` |
-
-### dimension.json
-
-Row and column metadata including sizes, visibility, and groups.
-
-```json
-{
-  "rowMetadata": [
-    { "row": 1, "pixelSize": 21 },
-    { "row": 11, "pixelSize": 50 },
-    { "row": 16, "pixelSize": 21, "hidden": true }
-  ],
-  "columnMetadata": [
-    { "column": "A", "pixelSize": 100 },
-    { "column": "B", "pixelSize": 80 },
-    { "column": "F", "pixelSize": 150 }
-  ],
-  "rowGroups": [
-    {
-      "range": "6:10",
-      "depth": 1,
-      "collapsed": false
-    }
-  ],
-  "columnGroups": [
-    {
-      "range": "C:E",
-      "depth": 1,
-      "collapsed": true
-    }
-  ],
-  "developerMetadata": [
-    {
-      "metadataId": 67890,
-      "metadataKey": "row-category",
-      "location": {
-        "dimensionRange": { "dimension": "ROWS", "startIndex": 0, "endIndex": 1 }
-      }
-    }
-  ]
-}
-```
-
-**Key conventions:**
-- **rowMetadata**: Uses 1-based row numbers (`"row": 5` = row 5)
-- **columnMetadata**: Uses column letters (`"column": "A"`)
-- **rowGroups/columnGroups range**: Uses A1-style notation (`"6:10"` for rows, `"C:E"` for columns)
-
-**Sparse Representation:**
-
-Only non-default dimensions are included:
-- Default row height: 21 pixels
-- Default column width: 100 pixels
-
-A dimension is considered non-default if:
-- `pixelSize` differs from default by more than 1 pixel
-- `hidden` is true
-- `developerMetadata` is present
-
-### protection.json
-
-Protected ranges and their permissions.
-
-```json
-{
-  "protectedRanges": [
-    {
-      "protectedRangeId": 12345,
-      "range": "A1:J1",
-      "description": "Header row - do not modify",
-      "warningOnly": false,
-      "requestingUserCanEdit": true,
-      "editors": {
-        "users": ["admin@example.com"],
-        "groups": ["admins@example.com"],
-        "domainUsersCanEdit": false
-      }
-    }
-  ]
-}
-```
-
----
-
-## Coordinate Systems
-
-### A1 Notation
-
-Used for human-readable cell references in formulas and format files.
-
-| Example | Description |
-|---------|-------------|
-| `A1` | Single cell (column A, row 1) |
-| `A1:D4` | Range from A1 to D4 |
-| `A:A` | Entire column A |
-| `1:1` | Entire row 1 |
-| `Sheet2!A1:D4` | Range on another sheet |
-
-### Zero-Based Indices
-
-Used in GridRange objects for API calls.
-
-```json
-{
-  "sheetId": 0,
-  "startRowIndex": 0,
-  "endRowIndex": 10,
-  "startColumnIndex": 0,
-  "endColumnIndex": 5
-}
-```
-
-- Indices are zero-based
-- Ranges are half-open: `[start, end)`
-- Missing index means unbounded
-
-### Column Letter Conversion
-
-```
-0 -> A, 1 -> B, ..., 25 -> Z
-26 -> AA, 27 -> AB, ..., 51 -> AZ
-52 -> BA, ..., 701 -> ZZ
-702 -> AAA, ...
-```
-
----
+- this is separate from `format.json.notes`
+- it is written per sheet
+- push supports adding replies and resolving comments
+- push does not support creating new top-level comments
 
 ## Special Sheet Types
 
-### OBJECT Sheets
+For non-GRID sheets:
 
-Sheets containing only embedded objects (charts, images) without grid data:
-- No `data.tsv` file
-- No `formula.json` file
-- `feature.json` contains the embedded object
+- `spreadsheet.json` still lists the sheet
+- no `data.tsv` or `formula.json` is written
+- feature files may still be written
 
-### DATA_SOURCE Sheets
+## Coordinate Conventions
 
-Sheets connected to external data sources:
-- `data.tsv` contains preview data (read-only)
-- `feature.json` contains data source configuration
+- Cells and ranges in JSON files use A1 notation.
+- `dimension.json` rows are 1-based and columns use letters.
+- Internally, diff/request generation converts those references back to the
+  Sheets API's 0-based indices.
 
----
+## Practical Gotchas
 
-## Encoding
-
-- **Character encoding:** UTF-8
-- **Line endings:** LF (`\n`) only
-- **JSON formatting:** Pretty-printed with 2-space indentation
-- **No BOM:** Byte Order Mark is not included
-
----
-
-## Gaps and Limitations
-
-### Not Currently Extracted
-
-1. **Chip runs** - Smart chips (people, dates, etc.) are not extracted
-2. **Comments** - Google Sheets comments (distinct from cell notes) are not extracted
-3. **Version history** - Not accessible via Sheets API
-4. **Images** - Embedded images are not extracted
-
-### Compression Limitations
-
-1. **Borders not compressed** - Border formatting is stored per-cell, not as range rules
-2. **Complex formulas** - Formulas with non-standard patterns may not compress well
-
-### Data Validation Representation
-
-1. **Non-contiguous ranges** - Cells are listed individually, not as ranges
-2. **Rule deduplication** - Uses JSON serialization for comparison, which may miss equivalent rules with different key ordering
-
-### Large Spreadsheet Handling
-
-Splitting large sheets into multiple `data_*.tsv` files is **not currently implemented**. All data goes into a single `data.tsv` regardless of size.
-
----
-
-## Known Limitations and Gotchas
-
-### Color Format Requirements
-
-All colors in editable files use **hex strings**: `"#RRGGBB"`
-
-Examples: `"#FF0000"` (red), `"#00FF00"` (green), `"#0000FF"` (blue)
-
-This applies to:
-- `formatRules[].format.backgroundColor`
-- `formatRules[].format.textFormat.foregroundColor`
-- `conditionalFormats[].booleanRule.format.backgroundColor`
-- `conditionalFormats[].gradientRule.*.color`
-- `textFormatRuns[].format.foregroundColor`
-- `bandedRanges[].rowProperties.*Color`
-
-The pull command normalizes all colors to hex. The push command converts hex to the API's RGB format internally.
-
-### Pristine State Not Updated After Push
-
-After successfully pushing changes, the `.pristine/spreadsheet.zip` is **NOT** automatically updated. This means:
-
-1. If you push changes and then push again without re-pulling, the diff will compare against the OLD pristine state
-2. This may cause errors like `Sheet with id XXXX already exists` if you created sheets
-
-**Workaround:** Always re-pull the spreadsheet after pushing changes before making additional edits.
-
-### Sheet IDs May Change After Push
-
-When creating new sheets, you may specify a `sheetId` in `spreadsheet.json`. However, Google may assign different IDs after the sheet is created.
-
-**Example:**
-- You specify `sheetId: 100, 200, 300` in your new sheets
-- After push and re-pull, Google may have assigned `sheetId: 1101, 1102, 1103`
-
-**Impact:** Charts, filters, pivot tables, and other features reference sheets by `sheetId`. After creating sheets, re-pull to get the server-assigned IDs before adding features that reference them.
-
-### A1 Notation Throughout
-
-ExtraSheet uses A1 notation consistently across all file formats:
-
-| Context | Convention | Example |
-|---------|------------|---------|
-| data.tsv line numbers | 1-based | Line 5 = row 5 in spreadsheet |
-| Cell references | A1 notation | `"A1"`, `"B5"`, `"AA100"` |
-| Range references | A1 notation | `"A1:B5"`, `"Sheet1!C3:D10"` |
-| Merges | A1 range | `{"range": "K50:L51"}` |
-| Tables/filters/banded ranges | A1 range | `{"range": "A1:J47"}` |
-| Chart anchor cells | A1 notation | `{"anchorCell": "F1"}` |
-| Chart source ranges | A1 range | `{"range": "A2:A13"}` |
-| Dimension metadata | Column letter / 1-based row | `{"column": "A"}`, `{"row": 5}` |
-
-The diff engine automatically converts A1 notation to 0-based indices when generating Google Sheets API requests. You never need to work with 0-based indices directly.
-
-### Unsupported Data Validation Types
-
-The following validation types are **NOT** supported by the Google Sheets API despite appearing in some documentation:
-- `TEXT_IS_VALID_EMAIL`
-- `TEXT_IS_VALID_URL`
-
-Using these types causes: `API error (400): Invalid value at 'requests[X].setDataValidation.rule.condition.type'`
-
-**Workaround:** Use `CUSTOM_FORMULA` with a regex pattern instead.
-
-### Conditional Format Rule Index Required
-
-Each conditional format rule must have a `ruleIndex` field specifying its position:
-
-```json
-{
-  "conditionalFormats": [
-    {
-      "ruleIndex": 0,
-      "ranges": ["A1:A10"],
-      "booleanRule": {...}
-    }
-  ]
-}
-```
-
-The `ruleIndex` determines the order rules are applied (lower indices are applied first).
-
-### Chart Structure Varies by Type
-
-Different chart types have different JSON structures:
-
-**Basic charts (bar, line, scatter, area, column):**
-```json
-{
-  "spec": {
-    "basicChart": {
-      "chartType": "BAR",
-      "domains": [...],   // Note: plural, array
-      "series": [...]     // Note: array
-    }
-  }
-}
-```
-
-**Pie charts:**
-```json
-{
-  "spec": {
-    "pieChart": {
-      "domain": {...},    // Note: singular, object
-      "series": {...}     // Note: object, not array
-    }
-  }
-}
-```
-
-### No Pre-flight Validation
-
-There is no validation before push to catch common errors. Issues are only discovered when the API returns a 400 error, sometimes after partial changes have been applied.
-
-Common errors that are not caught until push:
-- Invalid color formats (hex vs RGB mismatch)
-- Invalid data validation types
-- Malformed JSON structures
-- Sheet ID conflicts
-
-**Recommendation:** Always run `diff` before `push` to preview the generated requests.
-
----
-
-## API Type Definitions
-
-For complete TypedDict definitions of all Google Sheets API types, see `src/extrasheet/api_types.py`. This file is auto-generated from the Google Sheets API discovery document using `scripts/generate_types.py`.
+- Start with `spreadsheet.json`; it usually tells you whether you need to open
+  `data.tsv` at all.
+- If a sheet is truncated, use `--no-limit` or a higher `--max-rows` before
+  making decisions based on missing rows.
+- Re-pull after push.
+- Treat `theme.json`, `developer_metadata.json`, `data_sources.json`,
+  `protection.json`, and grouping metadata as pull-only unless the code changes.


### PR DESCRIPTION
## Summary
- audit the current extrasheet on-disk format against the implementation and a live pull of spreadsheet `1popsVtwuaYvGK8-ZkLIibesvbfnljjpUiOVWFMBMDkU`
- update `extrasheet` docs to match the current split feature files, truncation metadata, comments flow, and actual diff/push support
- update sheet help docs to distinguish editable files from pull-only informational files and clarify comments vs notes

## Verification
- pulled the live spreadsheet with `extrasuite sheet pull`
- confirmed the exported structure and `spreadsheet.json` truncation behavior
- ran `extrasuite sheet diff` on the untouched pulled folder and got `No changes detected.`