### PR TITLE
Add drive.readonly scope to credentials

### DIFF
--- a/client/src/extrasuite/client/credentials.py
+++ b/client/src/extrasuite/client/credentials.py
@@ -57,6 +57,7 @@ _OAUTH_USER_SCOPES = [
     "https://www.googleapis.com/auth/documents",
     "https://www.googleapis.com/auth/presentations",
     "https://www.googleapis.com/auth/drive.file",
+    "https://www.googleapis.com/auth/drive.readonly",
     "https://www.googleapis.com/auth/forms.body",
     "openid",
     "email",


### PR DESCRIPTION
`extrasuite docs pull` tries to fetch document comments which is prohibited without drive.readonly permissions