### PR TITLE
extradoc: fix insertTable footprint undercount corrupting downstream edits

### DIFF
--- a/extradoc/src/extradoc/mock/table_ops.py
+++ b/extradoc/src/extradoc/mock/table_ops.py
@@ -98,17 +98,29 @@ def handle_insert_table(
 
     # Step 5: Insert table into content array
     inject_content.insert(inject_idx, table_elem)
+    # A table is never the last element of a body segment, so the API emits a
+    # trailing carrier paragraph only when nothing (or another table) follows.
+    # When the step-1 split already left a following paragraph (the common mid-
+    # document insert), that paragraph IS the carrier; emitting another would
+    # over-count the footprint by one newline. See
+    # ``reconcile_v3.lower._batch_insert_size_from_reqs``.
     if segment_id is None:
-        inject_content.insert(
-            inject_idx + 1,
-            _build_table_carrier_paragraph(
-                paragraph_style=_resolve_preceding_paragraph_style(
-                    inject_idx,
-                    inject_content,
-                ),
-                text_style=inherited_text_style,
-            ),
+        following = (
+            inject_content[inject_idx + 1]
+            if inject_idx + 1 < len(inject_content)
+            else None
         )
+        if following is None or following.get("table") is not None:
+            inject_content.insert(
+                inject_idx + 1,
+                _build_table_carrier_paragraph(
+                    paragraph_style=_resolve_preceding_paragraph_style(
+                        inject_idx,
+                        inject_content,
+                    ),
+                    text_style=inherited_text_style,
+                ),
+            )
 
     # No index shifting — reindex handles it
     return {}

--- a/extradoc/src/extradoc/reconcile_v3/lower.py
+++ b/extradoc/src/extradoc/reconcile_v3/lower.py
@@ -1686,15 +1686,25 @@ def _final_doc_size_from_reqs(reqs: list[Request]) -> int:
 
 def _batch_insert_size_from_reqs(reqs: list[Request]) -> int:
     """Compute the net UTF-16 size added to the story segment by this element's
-    requests, measured as the sum of each insert request's own contribution.
+    requests — i.e. how far each insert shifts the content that follows it.
 
-    Differs from ``_final_doc_size_from_reqs`` in how ``insertTable`` is
-    counted: here we count only the table skeleton as the API delta
-    (``1 + rows * (1 + cols * 2)``), matching the request-level accounting
-    used by the matched-element post_insert_shift.  We do NOT add the
-    pre-paragraph \\n or trailing carrier paragraph here — those are either
-    absorbed into the existing paragraph structure or emitted as separate
-    ``insertText`` requests already counted above.
+    This value feeds ``post_insert_shift`` for matched-element updates, so it
+    MUST equal the true API footprint of the requests. An ``insertTable`` shifts
+    subsequent content by the table span PLUS exactly one ``\\n`` — never two:
+
+      * table span   → ``2 + rows * (1 + cols * 2)``
+          (table opener 1 + terminal 1 + rows*(row opener 1 + cols*cell 2))
+      * one ``\\n``   → 1
+    giving ``3 + rows*(1 + cols*2)``, which matches the per-request accounting
+    in ``_final_doc_size_from_reqs`` (``2 + rows*(1+cols*2) + 1``).
+
+    The single ``\\n`` is the pre-split newline when the table is inserted mid-
+    document (the following existing paragraph acts as the table's carrier), or
+    the trailing carrier newline when it is inserted at end-of-segment — never
+    both. The earlier ``4 + rows*(1+cols*2)`` over-counted the mid-document case
+    by 1, sliding every later matched-update op one char off. The offline mock
+    hid this because ``mock/table_ops`` also emitted both newlines; only a real
+    SUGGEST push + accepted-text verify exposes the disagreement.
     """
     total = 0
     for req in reqs:
@@ -1704,7 +1714,8 @@ def _batch_insert_size_from_reqs(reqs: list[Request]) -> int:
             it = req.insert_table
             rows = it.rows or 0
             cols = it.columns or 0
-            total += 1 + rows * (1 + cols * 2)
+            # table span (2 + rows*(1+cols*2)) + exactly one \n
+            total += 3 + rows * (1 + cols * 2)
         elif req.insert_page_break is not None:
             total += 2
         elif req.insert_section_break is not None:

--- a/extradoc/tests/reconcile_v3/test_story_content_update_bug.py
+++ b/extradoc/tests/reconcile_v3/test_story_content_update_bug.py
@@ -164,8 +164,14 @@ def _simulate_requests_and_find_stale_deletes(
                 idx = ins.location.index
                 rows = ins.rows or 0
                 cols = ins.columns or 0
-                # Table skeleton: 1 + rows * (1 + cols * 2) UTF-16 units.
-                delta = 1 + rows * (1 + cols * 2)
+                # Full body-segment insertTable footprint — how far it shifts
+                # subsequent content — matching the real API (controlled probe)
+                # and ``_batch_insert_size_from_reqs``: table span
+                # (2 + rows*(1+cols*2)) + exactly ONE \n. The API adds a single
+                # newline (the pre-split \n mid-doc, or the trailing carrier at
+                # end-of-segment) — never both, so the shift is span+1, not
+                # span+2.
+                delta = 3 + rows * (1 + cols * 2)
                 if idx > len(origins):
                     violations.append(
                         f"req[{req_idx}] insertTable: index={idx} > "


### PR DESCRIPTION
Closes #74.

> **Context & disclosure.** I hit this bug personally while using `reconcile_v3`
> in SUGGEST mode, and I've personally verified that this fix resolves it on a
> real document. That said, the investigation, the fix, and most of this write-up
> are largely AI-generated (Claude Opus) — I found the bug and confirmed the fix,
> but the prose and code are largely AI-authored, so please weight the detail
> accordingly.
>
> This surfaced specifically through **SUGGEST mode**, which isn't generally
> available yet and whose main PR hasn't landed — so it's completely fine if you'd
> rather not merge this now. I'm opening it mainly to share the finding upstream
> so anyone who hits the same thing can benefit, merged or not. I also haven't
> tested whether the same bug (or fix) manifests in **direct edits** without
> SUGGEST mode.
>
> This project has been really useful to me and I'd like to give back: if you want
> more human attention, deeper testing, or changes to make this mergeable, I'm
> happy to engage personally and put in the work — just say the word.

## What

`_batch_insert_size_from_reqs` (`reconcile_v3/lower.py`) undercounted the
footprint of a body `insertTable` by one `\n`, returning the bare table
skeleton `1 + rows*(1+cols*2)` instead of `3 + rows*(1+cols*2)`. That value
feeds `post_insert_shift`, so every matched-paragraph update op downstream of
an inserted table (in the same batch) was shifted one char early — corrupting
in-paragraph edits (text landing mid-word or past the wrong `\n`).

The corrected `3 + rows*(1+cols*2)` matches the sibling accounting in
`_final_doc_size_from_reqs` (`2 + rows*(1+cols*2) + 1`), which was already
correct; the two functions had silently disagreed by exactly the missing
newline. See #74 for the full root-cause, the real-API probe, and why the
offline mock hid the bug.

## Changes

- `reconcile_v3/lower.py` — footprint corrected to `3 + rows*(1+cols*2)`.
- `mock/table_ops.py::handle_insert_table` — emit the trailing carrier
  paragraph only when nothing (or another table) follows, so the offline
  oracle models the real span+1 instead of masking the bug.
- `tests/reconcile_v3/test_story_content_update_bug.py` — toy simulator
  updated to the real footprint; exercises the regression.

## Verification

- Full unit suite green (701 passed locally).
- Real-API SUGGEST push of an 8-amendment document: 227/227 paragraphs accept
  to exact desired text, in order (was 7/227 garbled before the fix).
